### PR TITLE
#12 Java에서 Elasticsearch를 이용해 bulk 요청 보내는 코드 작성하기

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -25,6 +25,9 @@ dependencies {
     implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
     implementation 'org.springframework.boot:spring-boot-starter-thymeleaf'
     implementation 'org.springframework.boot:spring-boot-starter-web'
+    // https://www.elastic.co/guide/en/elasticsearch/client/java-api-client/current/getting-started-java.html
+    implementation 'co.elastic.clients:elasticsearch-java:8.11.1'
+    implementation 'com.fasterxml.jackson.core:jackson-databind:2.12.7.1'
     compileOnly 'org.projectlombok:lombok'
     runtimeOnly 'com.mysql:mysql-connector-j'
     annotationProcessor 'org.projectlombok:lombok'

--- a/src/main/java/com/example/booksearching/elasticsearch/DataBaseIndexingApplication.java
+++ b/src/main/java/com/example/booksearching/elasticsearch/DataBaseIndexingApplication.java
@@ -1,0 +1,200 @@
+package com.example.booksearching.elasticsearch;
+
+import co.elastic.clients.elasticsearch.ElasticsearchClient;
+import co.elastic.clients.elasticsearch.core.BulkRequest;
+import co.elastic.clients.elasticsearch.core.BulkResponse;
+import co.elastic.clients.elasticsearch.core.bulk.BulkResponseItem;
+import co.elastic.clients.json.jackson.JacksonJsonpMapper;
+import co.elastic.clients.transport.ElasticsearchTransport;
+import co.elastic.clients.transport.TransportUtils;
+import co.elastic.clients.transport.rest_client.RestClientTransport;
+import com.example.booksearching.elasticsearch.analysis.HangulJamoMorphTokenizer;
+import com.example.booksearching.elasticsearch.model.Book;
+import com.example.booksearching.elasticsearch.model.BookDocument;
+import lombok.extern.slf4j.Slf4j;
+import org.apache.http.Header;
+import org.apache.http.HttpHost;
+import org.apache.http.auth.AuthScope;
+import org.apache.http.auth.UsernamePasswordCredentials;
+import org.apache.http.impl.client.BasicCredentialsProvider;
+import org.apache.http.message.BasicHeader;
+import org.elasticsearch.client.RestClient;
+
+import javax.net.ssl.SSLContext;
+import java.sql.*;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Optional;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicInteger;
+import java.util.stream.IntStream;
+
+@Slf4j
+public class DataBaseIndexingApplication {
+  public static List<Book> books;
+  public static List<BookDocument> bookDocs;
+  public static HangulJamoMorphTokenizer morphTokenizer;
+
+  public static void main(String[] args) {
+    morphTokenizer = HangulJamoMorphTokenizer.getInstance();
+    executeBookPipeline();
+    System.exit(0);
+  }
+
+  // https://discuss.elastic.co/t/api-key-unable-to-find-apikey-with-id/322104
+  // https://www.elastic.co/guide/en/kibana/current/api-keys.html
+  // https://www.elastic.co/guide/en/elasticsearch/reference/current/security-api-create-api-key.html
+
+  // https://www.elastic.co/guide/en/elasticsearch/client/java-api-client/current/connecting.html
+  // https://www.elastic.co/guide/en/elasticsearch/client/java-api-client/8.11/_other_authentication_methods.html
+  // https://www.elastic.co/guide/en/elasticsearch/client/java-api-client/current/_encrypted_communication.html
+
+  // https://www.elastic.co/guide/en/elasticsearch/client/java-api-client/current/indexing-bulk.html
+
+  public static void indexingDocs() {
+    // URL and API key
+    String host = "change me";
+    int port = 9200;
+    String encodedApiKey = "change me";
+
+    String fingerprint = "change me";
+
+    SSLContext sslContext = TransportUtils.sslContextFromCaFingerprint(fingerprint);
+
+    BasicCredentialsProvider credsProv = new BasicCredentialsProvider();
+    credsProv.setCredentials(AuthScope.ANY, new UsernamePasswordCredentials("elastic", "change me"));
+
+    try {
+      int totalSize = bookDocs.size();
+      int batchSize = 10000;
+      AtomicInteger completedDocumentCount = new AtomicInteger(0);
+
+      // Create the low-level client
+      RestClient restClient = RestClient
+              .builder(new HttpHost(host, port, "https"))
+              .setDefaultHeaders(new Header[]{
+                      new BasicHeader("Authorization", "ApiKey " + encodedApiKey)
+              })
+              .setHttpClientConfigCallback(httpAsyncClientBuilder -> httpAsyncClientBuilder
+                      .setSSLContext(sslContext)
+                      .setDefaultCredentialsProvider(credsProv)
+                      .setConnectionTimeToLive((30 * (long) Math.ceil(totalSize / (double) batchSize)), TimeUnit.SECONDS)
+              )
+              .build();
+
+      // Create the transport with a Jackson mapper
+      ElasticsearchTransport transport = new RestClientTransport(restClient, new JacksonJsonpMapper());
+
+      // And create the API client
+      ElasticsearchClient esClient = new ElasticsearchClient(transport);
+
+      long start = System.currentTimeMillis();
+
+      IntStream.range(0, (totalSize + batchSize - 1) / batchSize)
+              .mapToObj(i -> bookDocs.subList(i * batchSize, Math.min((i + 1) * batchSize, totalSize)))
+              .forEach(subList -> {
+                processBulkRequest(esClient, subList);
+                int cdc = completedDocumentCount.addAndGet(subList.size());
+                log.info(String.format("%.2f%% - %d/%d tasks completed!", 100.0 * cdc / (double)totalSize, cdc, totalSize));
+              });
+
+      long end = System.currentTimeMillis();
+      log.debug("수행시간: " + (end - start) + " ms");
+      log.debug("Total Generated Documents : {}", bookDocs.size());
+    } catch (Exception e) {
+      log.error("Create or request Elasticsearch request error", e);
+    }
+  }
+
+  public static void processBulkRequest(ElasticsearchClient esClient, List<BookDocument> bookDocs) {
+    BulkRequest.Builder br = new BulkRequest.Builder();
+
+    for (BookDocument bookDoc : bookDocs) {
+      br.operations(op -> op
+              .index(idx -> idx
+                      .index("books")
+                      .id(bookDoc.getIsbn_thirteen_no())
+                      .document(bookDoc))
+      );
+    }
+
+    BulkResponse result;
+    try {
+      result = esClient.bulk(br.build());
+
+      // Log errors, if any
+      if (result.errors()) {
+        log.error("Bulk had errors");
+        for (BulkResponseItem item : result.items()) {
+          if (item.error() != null) {
+            log.error(item.error().reason());
+          }
+        }
+      }
+    } catch (Exception e) {
+      log.error("Elasticsearch java api error [bulk]: ", e);
+    }
+  }
+
+  public static void executeBookPipeline() {
+    try {
+      readBookData();
+      translateBookDocuments();
+      indexingDocs();
+    } catch (Exception e) {
+      log.error("Error in executeBookPipeLine: ", e);
+    }
+  }
+
+  public static void readBookData() {
+    final String url = "change me";
+    final String username = "change me";
+    final String password = "change me";
+
+    try (Connection connection = DriverManager.getConnection(url, username, password)) {
+      log.info("Database Connected!");
+      Statement statement = connection.createStatement();
+      ResultSet resultSet = statement.executeQuery("SELECT * FROM books");
+      books = new ArrayList<>();
+
+      while (resultSet.next()) {
+        Book book = Book.of(
+                resultSet.getString("isbn_thirteen_no"),
+                resultSet.getString("title_nm"),
+                resultSet.getString("authr_nm"),
+                resultSet.getInt("pblicte_year")
+        );
+        books.add(book);
+      }
+    } catch (SQLException e) {
+      throw new IllegalStateException("Cannot connect the database!", e);
+    }
+  }
+
+  public static void translateBookDocuments() {
+    bookDocs = new ArrayList<>();
+    BookDocument doc;
+
+    log.info("Start translation...");
+    long start = System.currentTimeMillis();
+    for (Book book : books) {
+      doc = BookDocument.of(
+        book.getIsbnThirteenNo(),
+        book.getTitleName(),
+        morphTokenizer.chosungTokenizer(book.getTitleName()),
+        morphTokenizer.jamoTokenizer(book.getTitleName()),
+        morphTokenizer.convertKoreanToEnglish(book.getTitleName()),
+        book.getAuthorName(),
+        morphTokenizer.chosungTokenizer(Optional.ofNullable(book.getAuthorName()).orElse("")),
+        morphTokenizer.jamoTokenizer(Optional.ofNullable(book.getAuthorName()).orElse("")),
+        morphTokenizer.convertKoreanToEnglish(Optional.ofNullable(book.getAuthorName()).orElse("")),
+        book.getPublicationYear()
+      );
+      bookDocs.add(doc);
+    }
+    long end = System.currentTimeMillis();
+    log.info("수행시간: " + (end - start) + " ms");
+
+    log.info("Total Converted Documents : {}", bookDocs.size());
+  }
+}

--- a/src/main/java/com/example/booksearching/elasticsearch/model/Book.java
+++ b/src/main/java/com/example/booksearching/elasticsearch/model/Book.java
@@ -1,0 +1,35 @@
+package com.example.booksearching.elasticsearch.model;
+
+import lombok.Getter;
+import lombok.Setter;
+import lombok.ToString;
+
+import java.util.Optional;
+
+@Setter
+@Getter
+@ToString
+public class Book {
+    private String isbnThirteenNo;
+    private String titleName;
+    private String authorName;
+    private int publicationYear;
+
+    private Book(String isbnThirteenNo, String titleName, String authorName, int publicationYear) {
+        this.isbnThirteenNo = Optional.of(isbnThirteenNo)
+                .filter(s -> s.length() == 13)
+                .orElseThrow(() -> new IllegalArgumentException("String length is not 13"));
+        this.titleName = Optional.of(titleName).get();
+        this.authorName = authorName;
+        this.publicationYear = Optional.of(publicationYear).get();
+    }
+
+    public static Book of(String isbnThirteenNo, String titleName, String authorName, int publicationYear) {
+        return new Book(
+                isbnThirteenNo,
+                titleName,
+                authorName,
+                publicationYear
+        );
+    }
+}

--- a/src/main/java/com/example/booksearching/elasticsearch/model/BookDocument.java
+++ b/src/main/java/com/example/booksearching/elasticsearch/model/BookDocument.java
@@ -1,0 +1,51 @@
+package com.example.booksearching.elasticsearch.model;
+
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.ToString;
+
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@Getter
+@ToString
+public class BookDocument {
+    // Elasticsearch 필드 네이밍 규칙 : https://www.elastic.co/guide/en/ecs/current/ecs-guidelines.html
+    private String isbn_thirteen_no;
+    private String title;
+    private String title_chosung;
+    private String title_jamo;
+    private String title_engtokor;
+    private String author;
+    private String author_chosung;
+    private String author_jamo;
+    private String author_engtokor;
+    private int published_year;
+
+    private BookDocument(String isbnThirteenNo, String title, String titleChosung, String titleJamo, String titleEngToKor, String author, String authorChosung, String authorJamo, String authorEngToKor, int publishedYear) {
+        this.isbn_thirteen_no = isbnThirteenNo;
+        this.title = title;
+        this.title_chosung = titleChosung;
+        this.title_jamo = titleJamo;
+        this.title_engtokor = titleEngToKor;
+        this.author = author;
+        this.author_chosung = authorChosung;
+        this.author_jamo = authorJamo;
+        this.author_engtokor = authorEngToKor;
+        this.published_year = publishedYear;
+    }
+
+    public static BookDocument of(String isbnThirteenNo, String title, String titleChosung, String titleJamo, String titleEngToKor, String author, String authorChosung, String authorJamo, String authorEngToKor, int publishedYear) {
+        return new BookDocument(
+                isbnThirteenNo,
+                title,
+                titleChosung,
+                titleJamo,
+                titleEngToKor,
+                author,
+                authorChosung,
+                authorJamo,
+                authorEngToKor,
+                publishedYear
+        );
+    }
+}


### PR DESCRIPTION
# 변경된 사항
- Elasticsearch java low level client 의존성 추가
- DB와 Elasticsearch의 model들을 정의
- DB의 데이터를 가져와 변환하고, Elasticsearch에 indexing하는 코드를 작성
  - 10000개 씩 나눠서 bulk 요청을 보내도록 작성함
## 추가할 파일
- 9dfed94d15dff316606e7bd11b2f96def40088f7
  - src/main/java/com/example/booksearching/elasticsearch/model/BookDocument.java
  - src/main/java/com/example/booksearching/elasticsearch/model/Book.java
- 68711bececb483f005bb0c31e272df22912ec52d
  - src/main/java/com/example/booksearching/elasticsearch/DataBaseIndexingApplication.java
## 변경된 파일
- 61f20fafc2a7d9fff7204ef9068d7e3b79bf9a03
  - build.gradle
### 관련 이슈
- closes #12 