### PR TITLE
#23 클라이언트에 전달하기 위한 예외와 예외 핸들러 구현하기

### DIFF
--- a/src/main/java/com/example/booksearching/spring/exception/CustomException.java
+++ b/src/main/java/com/example/booksearching/spring/exception/CustomException.java
@@ -1,0 +1,7 @@
+package com.example.booksearching.spring.exception;
+
+public abstract class CustomException extends RuntimeException{
+
+    public abstract CustomExceptionType getCustomExceptionType();
+
+}

--- a/src/main/java/com/example/booksearching/spring/exception/CustomExceptionHandler.java
+++ b/src/main/java/com/example/booksearching/spring/exception/CustomExceptionHandler.java
@@ -1,0 +1,19 @@
+package com.example.booksearching.spring.exception;
+
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.ExceptionHandler;
+import org.springframework.web.bind.annotation.RestControllerAdvice;
+
+@Slf4j
+@RestControllerAdvice
+public class CustomExceptionHandler {
+
+    @ExceptionHandler(CustomException.class)
+    public ResponseEntity<String> customExceptionHandler(CustomException e) {
+        log.error(e.getCustomExceptionType().getErrorMsg());
+        return ResponseEntity.status(e.getCustomExceptionType().getHttpStatus())
+                .body(e.getCustomExceptionType().getErrorMsg());
+    }
+
+}

--- a/src/main/java/com/example/booksearching/spring/exception/CustomExceptionType.java
+++ b/src/main/java/com/example/booksearching/spring/exception/CustomExceptionType.java
@@ -1,0 +1,10 @@
+package com.example.booksearching.spring.exception;
+
+import org.springframework.http.HttpStatus;
+
+public interface CustomExceptionType {
+
+    HttpStatus getHttpStatus();
+    String getErrorMsg();
+
+}


### PR DESCRIPTION
# 변경된 사항
- 앞으로 생성할 모든 사용자 정의가 상속할 예외를 정의함
- 사용자 정의 예외가 발생한 경우, 핸들러에서 로그를 발생시키고 클라이언트에 전달

## 추가된파일
- 6355c02bd4148b27a74fb9659ca79e42a81c39cd
  - src/main/java/com/example/booksearching/spring/exception/CustomException.java
  - src/main/java/com/example/booksearching/spring/exception/CustomExceptionType.java
- 84761de708746e94958610de22f33ffff41e257f
  - src/main/java/com/example/booksearching/spring/exception/CustomExceptionHandler.java

### 관련 이슈
- closes #23 
