### PR TITLE
#21 검색 자동 완성 기능 구현하기

### DIFF
--- a/src/main/java/com/example/booksearching/spring/config/ElasticSearchClientConfig.java
+++ b/src/main/java/com/example/booksearching/spring/config/ElasticSearchClientConfig.java
@@ -1,0 +1,71 @@
+package com.example.booksearching.spring.config;
+
+import co.elastic.clients.elasticsearch.ElasticsearchClient;
+import co.elastic.clients.json.jackson.JacksonJsonpMapper;
+import co.elastic.clients.transport.ElasticsearchTransport;
+import co.elastic.clients.transport.TransportUtils;
+import co.elastic.clients.transport.rest_client.RestClientTransport;
+import org.apache.http.Header;
+import org.apache.http.HttpHost;
+import org.apache.http.auth.AuthScope;
+import org.apache.http.auth.UsernamePasswordCredentials;
+import org.apache.http.client.CredentialsProvider;
+import org.apache.http.impl.client.BasicCredentialsProvider;
+import org.apache.http.message.BasicHeader;
+import org.elasticsearch.client.RestClient;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+@Configuration
+public class ElasticSearchClientConfig
+{
+    @Value("${elasticsearch.host}")
+    private String host;
+
+    @Value("${elasticsearch.port}")
+    private Integer port;
+
+    @Value("${elasticsearch.username}")
+    private String username;
+
+    @Value("${elasticsearch.password}")
+    private String password;
+
+    @Value("${elasticsearch.encodedApiKey}")
+    String encodedApiKey;
+
+    @Value("${elasticsearch.fingerprint}")
+    String fingerprint;
+
+    CredentialsProvider credentials = new BasicCredentialsProvider();
+
+
+    @Bean
+    public RestClient getRestClient() {
+
+        credentials.setCredentials(AuthScope.ANY, new UsernamePasswordCredentials(username, password));
+
+        return RestClient.builder(
+                        new HttpHost(host, port, "https"))
+                .setDefaultHeaders(new Header[]{
+                        new BasicHeader("Authorization", "ApiKey " + encodedApiKey)
+                })
+                .setHttpClientConfigCallback(httpAsyncClientBuilder -> httpAsyncClientBuilder
+                        .setSSLContext(TransportUtils.sslContextFromCaFingerprint(fingerprint))
+                        .setDefaultCredentialsProvider(credentials)
+                )
+                .build();
+    }
+
+    @Bean
+    public ElasticsearchTransport getElasticsearchTransport() {
+        return new RestClientTransport(getRestClient(), new JacksonJsonpMapper());
+    }
+
+    @Bean
+    public ElasticsearchClient getElasticsearchClient() {
+        return new ElasticsearchClient(getElasticsearchTransport());
+    }
+
+}

--- a/src/main/java/com/example/booksearching/spring/controller/BookController.java
+++ b/src/main/java/com/example/booksearching/spring/controller/BookController.java
@@ -1,0 +1,27 @@
+package com.example.booksearching.spring.controller;
+
+import com.example.booksearching.spring.dto.BookSearchResponse;
+import com.example.booksearching.spring.service.BookService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Controller;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.ResponseBody;
+
+import java.util.List;
+
+@RequiredArgsConstructor
+@RequestMapping("/books")
+@Controller
+public class BookController {
+
+    private final BookService bookService;
+    
+    @GetMapping("/search")
+    @ResponseBody
+    public List<BookSearchResponse> getSearch(@RequestParam(required = false) String keyword) {
+        return bookService.searchBookTitles(keyword);
+    }
+
+}

--- a/src/main/java/com/example/booksearching/spring/dto/BookSearchResponse.java
+++ b/src/main/java/com/example/booksearching/spring/dto/BookSearchResponse.java
@@ -1,0 +1,40 @@
+package com.example.booksearching.spring.dto;
+
+import co.elastic.clients.elasticsearch.core.search.Hit;
+import com.example.booksearching.elasticsearch.model.BookDocument;
+
+import java.time.Year;
+import java.util.List;
+import java.util.Map;
+
+public record BookSearchResponse(
+        String isbn,
+        String title,
+        String highlightTitle,
+        String author,
+        Year publishedYear
+) {
+
+    public static BookSearchResponse of(String isbn, String title, String highlightTitle, String author, Year publishedYear) {
+        return new BookSearchResponse(isbn, title, highlightTitle, author, publishedYear);
+    }
+
+    public static BookSearchResponse from(Hit<BookDocument> hit) {
+        assert hit.source() != null;
+        BookDocument doc = hit.source();
+        Map<String, List<String>> resultHighlights = hit.highlight();
+
+        return BookSearchResponse.of(
+                doc.getIsbn_thirteen_no(),
+                doc.getTitle(),
+                resultHighlights.entrySet().stream()
+                        .findFirst()
+                        .filter(entry -> !entry.getValue().isEmpty())
+                        .map(entry -> entry.getValue().get(0))
+                        .orElse(doc.getTitle()),
+                doc.getAuthor(),
+                Year.of(doc.getPublished_year())
+        );
+    }
+
+}

--- a/src/main/java/com/example/booksearching/spring/exception/ElasticsearchCommunicationException.java
+++ b/src/main/java/com/example/booksearching/spring/exception/ElasticsearchCommunicationException.java
@@ -1,0 +1,14 @@
+package com.example.booksearching.spring.exception;
+
+import lombok.RequiredArgsConstructor;
+
+@RequiredArgsConstructor
+public class ElasticsearchCommunicationException extends CustomException {
+
+    private final ElasticsearchCommunicationExceptionType elasticsearchCommunicationExceptionType;
+
+    @Override
+    public CustomExceptionType getCustomExceptionType() {
+        return elasticsearchCommunicationExceptionType;
+    }
+}

--- a/src/main/java/com/example/booksearching/spring/exception/ElasticsearchCommunicationExceptionType.java
+++ b/src/main/java/com/example/booksearching/spring/exception/ElasticsearchCommunicationExceptionType.java
@@ -1,0 +1,24 @@
+package com.example.booksearching.spring.exception;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+
+@RequiredArgsConstructor
+public enum ElasticsearchCommunicationExceptionType implements CustomExceptionType {
+
+    ELASTICSEARCH_SEARCH_FAIL(HttpStatus.INTERNAL_SERVER_ERROR, "Elasticsearch가 요청을 처리하던 도중, 오류가 발생했습니다."),
+    ELASTICSEARCH_IO_FAIL(HttpStatus.INTERNAL_SERVER_ERROR, "Elasticsearch 관련 입출력 작업 중 오류가 발생했습니다.");
+
+    private final HttpStatus httpStatus;
+    private final String errorMsg;
+
+    @Override
+    public HttpStatus getHttpStatus() {
+        return httpStatus;
+    }
+    @Override
+    public String getErrorMsg() {
+        return errorMsg;
+    }
+
+}

--- a/src/main/java/com/example/booksearching/spring/service/BookService.java
+++ b/src/main/java/com/example/booksearching/spring/service/BookService.java
@@ -1,0 +1,139 @@
+package com.example.booksearching.spring.service;
+
+import co.elastic.clients.elasticsearch.ElasticsearchClient;
+import co.elastic.clients.elasticsearch._types.ElasticsearchException;
+import co.elastic.clients.elasticsearch._types.query_dsl.*;
+import co.elastic.clients.elasticsearch.core.SearchRequest;
+import co.elastic.clients.elasticsearch.core.SearchResponse;
+import co.elastic.clients.elasticsearch.core.search.*;
+import com.example.booksearching.elasticsearch.model.BookDocument;
+import com.example.booksearching.spring.dto.BookSearchResponse;
+import com.example.booksearching.spring.entity.Book;
+import com.example.booksearching.spring.exception.ElasticsearchCommunicationException;
+import com.example.booksearching.spring.exception.ElasticsearchCommunicationExceptionType;
+import com.example.booksearching.spring.repository.BookRepository;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.io.IOException;
+import java.util.*;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
+
+@Slf4j
+@RequiredArgsConstructor
+@Transactional
+@Service
+public class BookService {
+
+    private final BookRepository bookRepository;
+    private final ElasticsearchClient esClient;
+
+    public Book saveDocInfo(Book book) {
+        return bookRepository.save(book);
+    }
+
+    public List<BookSearchResponse> searchBookTitles(String keyword) {
+        final String BOOK_INDEX = "books";
+        final String FIELD_NAME = "title";
+        final Integer SIZE = 10;
+        final Float DEFAULT_BOOST_VALUE = 1f;
+        final Float PARTIAL_BOOST_VALUE = 0.3f;
+
+        // field = {"", "_engtokor", "_chosung", "_jamo"}
+        Map<String, Float> fieldBoostMap = Map.of(
+                "", DEFAULT_BOOST_VALUE,
+                "_engtokor", DEFAULT_BOOST_VALUE
+        );
+        Map<String, Float> koreanPhonemefieldBoostMap = Map.of(
+                "_chosung", DEFAULT_BOOST_VALUE,
+                "_jamo", DEFAULT_BOOST_VALUE
+        );
+
+        // option = {".exact", ".edge", ".partial"}
+        Map<String, Float> optionBoostMap = Map.of(
+                ".exact", DEFAULT_BOOST_VALUE,
+                ".edge", DEFAULT_BOOST_VALUE,
+                ".partial", PARTIAL_BOOST_VALUE
+        );
+
+        // MultiMatchQuery 생성
+        MultiMatchQuery multiMatchQuery = createMultiMatchQuery(keyword, FIELD_NAME, fieldBoostMap, optionBoostMap, TextQueryType.BestFields);
+        MultiMatchQuery koreanPhonemeMultiMatchQuery = createMultiMatchQuery(keyword, FIELD_NAME, koreanPhonemefieldBoostMap, optionBoostMap, TextQueryType.Phrase);
+
+        // Highlight 생성
+        Highlight highlight = createHighlightFieldMap(
+                Stream.of(multiMatchQuery.fields(), koreanPhonemeMultiMatchQuery.fields())
+                        .flatMap(Collection::stream)
+                        .toList()
+        );
+
+        SearchRequest searchRequest = new SearchRequest.Builder()
+                .index(BOOK_INDEX)
+                .size(SIZE)
+                .query(queryBuilder ->
+                        queryBuilder.bool(boolBuilder ->
+                                boolBuilder.should(
+                                        List.of(
+                                                multiMatchQuery._toQuery(),
+                                                koreanPhonemeMultiMatchQuery._toQuery()
+                                        )
+                                )
+                        )
+                )
+                .highlight(highlight)
+                .build();
+
+        SearchResponse<BookDocument> response = null;
+        try {
+            response = esClient.search(searchRequest, BookDocument.class);
+        } catch (ElasticsearchException e) {
+            throw new ElasticsearchCommunicationException(ElasticsearchCommunicationExceptionType.ELASTICSEARCH_SEARCH_FAIL);
+        } catch (IOException e) {
+            throw new ElasticsearchCommunicationException(ElasticsearchCommunicationExceptionType.ELASTICSEARCH_IO_FAIL);
+        }
+
+        TotalHits total = response.hits().total();
+        assert total != null;
+        boolean isExactResult = total.relation() == TotalHitsRelation.Eq;
+        log.info("There are " + (isExactResult ? "" : "more than ") + total.value() + " results");
+
+        List<Hit<BookDocument>> hits = response.hits().hits();
+        List<BookSearchResponse> res = hits.stream().map(BookSearchResponse::from).toList();
+
+        log.info("Search result: {{}}", res.stream().map(BookSearchResponse::toString).collect(Collectors.joining(",\n")));
+
+        return res;
+    }
+
+    private List<String> createMultiMatchFieldList(String fieldName, Map<String, Float> fieldBoostMap, Map<String, Float> optionBoostMap) {
+        return fieldBoostMap.entrySet().stream()
+                .flatMap(fieldBoostEntry ->
+                    optionBoostMap.entrySet().stream()
+                            .map(optionBoostEntry -> fieldName + fieldBoostEntry.getKey() + optionBoostEntry.getKey() + "^" + fieldBoostEntry.getValue() * optionBoostEntry.getValue())
+                ).toList();
+    }
+
+    private MultiMatchQuery createMultiMatchQuery(String keyword, String fieldName, Map<String, Float> fieldBoostMap, Map<String, Float> optionBoostMap, TextQueryType queryType) {
+        return new MultiMatchQuery.Builder()
+                .query(keyword)
+                .type(queryType)
+                .fields(createMultiMatchFieldList(fieldName, fieldBoostMap, optionBoostMap))
+                .build();
+    }
+
+    // https://stackoverflow.com/questions/71351777/how-to-explicitly-order-highlighted-fields-using-elasticsearch-java-api-client
+    private Highlight createHighlightFieldMap(List<String> fieldNames) {
+        Map<String, HighlightField> highlightFieldMap = new HashMap<>();
+        for (String fieldName : fieldNames) {
+            highlightFieldMap.put(
+                    fieldName.substring(0, fieldName.lastIndexOf('^')),
+                    new HighlightField.Builder().postTags("</strong>").preTags("<strong>").build()
+            );
+        }
+        return new Highlight.Builder().fields(highlightFieldMap).build();
+    }
+
+}

--- a/src/main/resources/application.yaml
+++ b/src/main/resources/application.yaml
@@ -1,8 +1,8 @@
 spring:
   datasource:
-    url: jdbc:mysql://localhost:3306/doc_searching?serverTimezone=UTC
-    username: root
-    password: 
+    url: change me
+    username: change me
+    password: change me
     driver-class-name: com.mysql.cj.jdbc.Driver
   jpa:
     # When the application is executed, JPA automatically generates the database schema based on the entities
@@ -12,3 +12,17 @@ spring:
       hibernate:
         # Hibernate in interacting with a MySQL database is to understand and support the SQL syntax and characteristics specific to MySQL, enabling it to generate appropriate SQL queries
         dialect: org.hibernate.dialect.MySQLDialect
+
+database:
+  url: change me
+  username: change me
+  password: change me
+
+# elasticsearch configuration
+elasticsearch:
+  host: change me
+  port: 9200
+  username: elastic
+  password: change me
+  encodedApiKey: change me
+  fingerprint: change me


### PR DESCRIPTION
# 변경된 사항
- `ElasticSearchClientConfig`를 이용해 Elasticsearch client 연결에 대한 정보를 설정하고 bean으로 등록하여 사용
- 민감한 정보는 application.yaml 파일에 작성하고 `@Value`를 이용해서 사용
- 해당 클라이언트의 `search` 메서드 사용 중에 발생할 수 있는 예외를 사용자 정의
- Elasticsearch를 이용해 받은 데이터를 클라이언트에 전달할 DTO 정의
- 자동 완성 기능을 수행하는 서비스 메서드 구현
- `BookController`에 자동 완성 관련 매핑을 추가
- 경로를 docinfos에서 books로 변경

## 추가할 파일
- a02f43fd4984cc324a37477b36630feb15eb4e97
  - src/main/java/com/example/booksearching/spring/config/ElasticSearchClientConfig.java
- 52e397c2d2708205da4d795bc6002cf656f28e94
  - src/main/java/com/example/booksearching/spring/exception/ElasticsearchCommunicationException.java
  - src/main/java/com/example/booksearching/spring/exception/ElasticsearchCommunicationExceptionType.java
- 9898943c6e4bcfc962d417b210a9a0eb1f4c0f1e
  - src/main/java/com/example/booksearching/spring/dto/BookSearchResponse.java
  
## 수정된 파일
- a02f43fd4984cc324a37477b36630feb15eb4e97
  - src/main/resources/application.yaml 
- 05c88228d4562f234aedb1e880e25ff6a7c240f0
  - src/main/java/com/example/booksearching/spring/service/BookService.java
- 4f36e631e97d115098602697cd3d8a4a8d45719a
  - src/main/java/com/example/booksearching/spring/controller/BookController.java

## 추가 사항
- 해당 변경에는 (#22) 에서 누락되었던 네이밍 변경 (#13) , 폴더 이동 (#18) 이 포함되어 있음
  - BookService.java
  - BookController.java

### 관련 이슈
- closes #21  
