### PR TITLE
#13 - DocInfo를 Book으로 변환하기

### DIFF
--- a/src/main/java/com/example/booksearching/spring/config/WebConfig.java
+++ b/src/main/java/com/example/booksearching/spring/config/WebConfig.java
@@ -9,7 +9,7 @@ public class WebConfig implements WebMvcConfigurer {
 
     @Override
     public void addCorsMappings(CorsRegistry registry) {
-        registry.addMapping("/docinfos/**")
+        registry.addMapping("/books/**")
                 .allowedOrigins("http://localhost:63342")
                 .allowedMethods("GET")
                 .allowCredentials(true);


### PR DESCRIPTION
# 변경된 사항
- WebConfig.java 파일에 CORS 설정 중, 5c40734 혹은 4f36e631e97d115098602697cd3d8a4a8d45719a 에서 누락된 엔드포인트 명 변경 (63342 포트는 intellij에서 지원하는 로컬 웹 서버)
  
## 수정된 파일
-edd29e48ba6ebb6d7a6c2f495f2356403e20835c
  - src/main/java/com/example/booksearching/spring/config/WebConfig.java
 
### 관련 이슈
- closes #13
