### PR TITLE
#19 - elasticsearch의 mapping 정보와 동일하게 entity 수정

### DIFF
--- a/src/main/java/com/example/booksearching/elasticsearch/model/BookDocument.java
+++ b/src/main/java/com/example/booksearching/elasticsearch/model/BookDocument.java
@@ -16,25 +16,19 @@ public class BookDocument {
     private String title_jamo;
     private String title_engtokor;
     private String author;
-    private String author_chosung;
-    private String author_jamo;
-    private String author_engtokor;
     private int published_year;
 
-    private BookDocument(String isbnThirteenNo, String title, String titleChosung, String titleJamo, String titleEngToKor, String author, String authorChosung, String authorJamo, String authorEngToKor, int publishedYear) {
+    private BookDocument(String isbnThirteenNo, String title, String titleChosung, String titleJamo, String titleEngToKor, String author, int publishedYear) {
         this.isbn_thirteen_no = isbnThirteenNo;
         this.title = title;
         this.title_chosung = titleChosung;
         this.title_jamo = titleJamo;
         this.title_engtokor = titleEngToKor;
         this.author = author;
-        this.author_chosung = authorChosung;
-        this.author_jamo = authorJamo;
-        this.author_engtokor = authorEngToKor;
         this.published_year = publishedYear;
     }
 
-    public static BookDocument of(String isbnThirteenNo, String title, String titleChosung, String titleJamo, String titleEngToKor, String author, String authorChosung, String authorJamo, String authorEngToKor, int publishedYear) {
+    public static BookDocument of(String isbnThirteenNo, String title, String titleChosung, String titleJamo, String titleEngToKor, String author, int publishedYear) {
         return new BookDocument(
                 isbnThirteenNo,
                 title,
@@ -42,9 +36,6 @@ public class BookDocument {
                 titleJamo,
                 titleEngToKor,
                 author,
-                authorChosung,
-                authorJamo,
-                authorEngToKor,
                 publishedYear
         );
     }


### PR DESCRIPTION
# 변경된 사항
- BookDocument 엔티티를 #19 이슈에 작성한 인덱스 매핑 정보와 동일하게 수정
  - author는 초성, 자모, 영한 데이터를 추가하지 않음
  
## 수정된 파일
- fe352fccb5d5fa2c67fd71d0420a7ec65c42f201
  - src/main/java/com/example/booksearching/elasticsearch/model/BookDocument.java
 
### 관련 이슈
- closes #19 
