### PR TITLE
#19 - 누락된 수정 추가 커밋

### DIFF
--- a/src/main/java/com/example/booksearching/elasticsearch/DataBaseIndexingApplication.java
+++ b/src/main/java/com/example/booksearching/elasticsearch/DataBaseIndexingApplication.java
@@ -185,9 +185,6 @@ public class DataBaseIndexingApplication {
         morphTokenizer.jamoTokenizer(book.getTitleName()),
         morphTokenizer.convertKoreanToEnglish(book.getTitleName()),
         book.getAuthorName(),
-        morphTokenizer.chosungTokenizer(Optional.ofNullable(book.getAuthorName()).orElse("")),
-        morphTokenizer.jamoTokenizer(Optional.ofNullable(book.getAuthorName()).orElse("")),
-        morphTokenizer.convertKoreanToEnglish(Optional.ofNullable(book.getAuthorName()).orElse("")),
         book.getPublicationYear()
       );
       bookDocs.add(doc);


### PR DESCRIPTION
# 변경된 사항
- #28 에서 누락된 변경 사항 추가
  - #28에서 BookDocument의 author와 관련된 정보인 초성, 자모, 영한 필드를 삭제했기 때문에, DB -> Elasticsearch로 변환하는 과정도 수정
  
## 수정된 파일
- 54b0dbada57b36ad279860203717ea97b1f42c47
  - src/main/java/com/example/booksearching/elasticsearch/DataBaseIndexingApplication.java
 
### 관련 이슈
- closes #19
