### PR TITLE
#15 - HangulJamoMorphTokenizer 수정 및 개선 (+ #12 #30)

### DIFF
--- a/src/main/java/com/example/booksearching/elasticsearch/DataBaseIndexingApplication.java
+++ b/src/main/java/com/example/booksearching/elasticsearch/DataBaseIndexingApplication.java
@@ -8,6 +8,7 @@ import co.elastic.clients.json.jackson.JacksonJsonpMapper;
 import co.elastic.clients.transport.ElasticsearchTransport;
 import co.elastic.clients.transport.TransportUtils;
 import co.elastic.clients.transport.rest_client.RestClientTransport;
+import com.example.booksearching.elasticsearch.analysis.HanguelJamoType;
 import com.example.booksearching.elasticsearch.analysis.HangulJamoMorphTokenizer;
 import com.example.booksearching.elasticsearch.model.Book;
 import com.example.booksearching.elasticsearch.model.BookDocument;
@@ -24,7 +25,6 @@ import javax.net.ssl.SSLContext;
 import java.sql.*;
 import java.util.ArrayList;
 import java.util.List;
-import java.util.Optional;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.stream.IntStream;
@@ -181,9 +181,9 @@ public class DataBaseIndexingApplication {
       doc = BookDocument.of(
         book.getIsbnThirteenNo(),
         book.getTitleName(),
-        morphTokenizer.chosungTokenizer(book.getTitleName()),
-        morphTokenizer.jamoTokenizer(book.getTitleName()),
-        morphTokenizer.convertKoreanToEnglish(book.getTitleName()),
+        morphTokenizer.tokenizer(book.getTitleName(), HanguelJamoType.CHOSUNG),
+        morphTokenizer.tokenizer(book.getTitleName(), HanguelJamoType.JAMO),
+        morphTokenizer.tokenizer(book.getTitleName(), HanguelJamoType.KORTOENG),
         book.getAuthorName(),
         book.getPublicationYear()
       );

--- a/src/main/java/com/example/booksearching/elasticsearch/DataBaseIndexingApplication.java
+++ b/src/main/java/com/example/booksearching/elasticsearch/DataBaseIndexingApplication.java
@@ -88,6 +88,7 @@ public class DataBaseIndexingApplication {
       // And create the API client
       ElasticsearchClient esClient = new ElasticsearchClient(transport);
 
+      log.info("Start indexing...");
       long start = System.currentTimeMillis();
 
       IntStream.range(0, (totalSize + batchSize - 1) / batchSize)
@@ -99,8 +100,8 @@ public class DataBaseIndexingApplication {
               });
 
       long end = System.currentTimeMillis();
-      log.debug("수행시간: " + (end - start) + " ms");
-      log.debug("Total Generated Documents : {}", bookDocs.size());
+      log.info("수행시간: " + (end - start) + " ms");
+      log.info("Total Generated Documents : {}", bookDocs.size());
     } catch (Exception e) {
       log.error("Create or request Elasticsearch request error", e);
     }
@@ -175,7 +176,7 @@ public class DataBaseIndexingApplication {
     bookDocs = new ArrayList<>();
     BookDocument doc;
 
-    log.info("Start translation...");
+    log.info("Start converting...");
     long start = System.currentTimeMillis();
     for (Book book : books) {
       doc = BookDocument.of(

--- a/src/main/java/com/example/booksearching/elasticsearch/DataBaseIndexingApplication.java
+++ b/src/main/java/com/example/booksearching/elasticsearch/DataBaseIndexingApplication.java
@@ -139,7 +139,7 @@ public class DataBaseIndexingApplication {
   public static void executeBookPipeline() {
     try {
       readBookData();
-      translateBookDocuments();
+      convertBookToBookDocument();
       indexingDocs();
     } catch (Exception e) {
       log.error("Error in executeBookPipeLine: ", e);
@@ -171,7 +171,7 @@ public class DataBaseIndexingApplication {
     }
   }
 
-  public static void translateBookDocuments() {
+  public static void convertBookToBookDocument() {
     bookDocs = new ArrayList<>();
     BookDocument doc;
 

--- a/src/main/java/com/example/booksearching/elasticsearch/analysis/HangulJamoMorphTokenizer.java
+++ b/src/main/java/com/example/booksearching/elasticsearch/analysis/HangulJamoMorphTokenizer.java
@@ -23,6 +23,7 @@ public class HangulJamoMorphTokenizer {
       "ho", "hl", "y", "n", "nj", "np", "nl", "b", "m", "ml", "l"};
   private static String[] JONGSUNG_EN = {"", "r", "R", "rt", "s", "sw", "sg", "e", "f", "fr", "fa",
           "fq", "ft", "fx", "fv", "fg", "a", "q", "qt", "t", "T", "d", "w", "c", "z", "x", "v", "g"};
+  // https://www.unicode.org/charts/
   private static final char CHOSUNG_BEGIN_UNICODE = 0x3131;
   private static final char CHOSUNG_END_UNICODE = 0x314E;
   private static final char HANGUEL_BEGIN_UNICODE = 0xAC00;
@@ -35,9 +36,9 @@ public class HangulJamoMorphTokenizer {
   private static final char ENGLISH_UPPER_END_UNICODE = 0x007A;
   private static final char WHITESPACE_UNICODE = 0x0020;
   private volatile static HangulJamoMorphTokenizer hangulJamoMorphTokenizer;
-  private static String[] LETTER_EN = {"r", "R", "rt", "s", "sw", "sg", "e", "E", "f", "fr", "fa",
-      "fq", "ft", "fx", "fv", "fg", "a", "q", "Q", "qt", "t", "T", "d", "w", "W", "c", "z", "x",
-      "v", "g"};
+//  private static String[] LETTER_EN = {"r", "R", "rt", "s", "sw", "sg", "e", "E", "f", "fr", "fa",
+//      "fq", "ft", "fx", "fv", "fg", "a", "q", "Q", "qt", "t", "T", "d", "w", "W", "c", "z", "x",
+//      "v", "g"};
 
   private HangulJamoMorphTokenizer() {
   }
@@ -54,20 +55,15 @@ public class HangulJamoMorphTokenizer {
   }
 
   private static boolean isPossibleCharacter(char c) {
-    if (((c >= NUMBER_BEGIN_UNICODE && c <= NUMBER_END_UNICODE)
-        || (c >= ENGLISH_UPPER_BEGIN_UNICODE && c <= ENGLISH_UPPER_END_UNICODE)
-        || (c >= ENGLISH_LOWER_BEGIN_UNICODE && c <= ENGLISH_LOWER_END_UNICODE)
-        || (c >= HANGUEL_BEGIN_UNICODE && c <= HANGUEL_END_UNICODE)
-        || (c >= CHOSUNG_BEGIN_UNICODE && c <= CHOSUNG_END_UNICODE)
-        || c == WHITESPACE_UNICODE)
-    ) {
-      return true;
-    } else {
-      return false;
-    }
+      return (c >= NUMBER_BEGIN_UNICODE && c <= NUMBER_END_UNICODE)
+              || (c >= ENGLISH_UPPER_BEGIN_UNICODE && c <= ENGLISH_UPPER_END_UNICODE)
+              || (c >= ENGLISH_LOWER_BEGIN_UNICODE && c <= ENGLISH_LOWER_END_UNICODE)
+              || (c >= HANGUEL_BEGIN_UNICODE && c <= HANGUEL_END_UNICODE)
+              || (c >= CHOSUNG_BEGIN_UNICODE && c <= CHOSUNG_END_UNICODE)
+              || c == WHITESPACE_UNICODE;
   }
 
-  public String tokenizer(String source, String jamoType) {
+  public String tokenizer(String source, HanguelJamoType jamoType) {
     /*
     [분리 기본 공식]
     초성 = ( ( (글자 - 0xAC00) - (글자 - 0xAC00) % 28 ) ) / 28 ) / 21
@@ -78,19 +74,20 @@ public class HangulJamoMorphTokenizer {
     각 index 정보는 CHOSUNG, JUNGSUNG, JONGSUNG char[]에 정의한 index 입니다.
     하지만 아래 코드에서는 원문이 필요 없기 때문에 합치기 위한 로직은 포함 되어 있지 않습니다.
     */
-    String jamo = switch (jamoType) {
-      case "CHOSUNG" -> chosungTokenizer(source);
-      case "JUNGSUNG" -> jungsungTokenizer(source);
-      case "JONGSUNG" -> jongsungTokenizer(source);
-      case "KORTOENG" -> convertKoreanToEnglish(source);
-      default -> jamoTokenizer(source);
     // 한글을 포함하지 않았다면, tokenizing에서 제외
     if (!containsKorean(source)) {
       return null;
     }
-    };
 
-    return jamo;
+    return switch (jamoType) {
+      case CHOSUNG -> chosungTokenizer(source);
+      case JUNGSUNG -> jungsungTokenizer(source);
+      case JONGSUNG -> jongsungTokenizer(source);
+      case KORTOENG -> convertKoreanToEnglish(source);
+      case JAMO -> jamoTokenizer(source);
+    };
+  }
+
   private boolean containsKorean(String text) {
     return text != null && text.matches(".*[ㄱ-ㅎㅏ-ㅣ가-힣]+.*");
   }
@@ -171,29 +168,14 @@ public class HangulJamoMorphTokenizer {
   }
 
   public String chosungDoubleToSingle(String chosung) {
-    String single = "";
-
-    switch (chosung) {
-      case "ㄲ" :
-        single = "ㄱㄱ";
-        break;
-      case "ㄸ" :
-        single = "ㄷㄷ";
-        break;
-      case "ㅃ" :
-        single = "ㅂㅂ";
-        break;
-      case "ㅆ" :
-        single = "ㅅㅅ";
-        break;
-      case "ㅉ" :
-        single = "ㅈㅈ";
-        break;
-      default :
-        single = chosung;
-    }
-
-    return single;
+    return switch (chosung) {
+        case "ㄲ" -> "ㄱㄱ";
+        case "ㄸ" -> "ㄷㄷ";
+        case "ㅃ" -> "ㅂㅂ";
+        case "ㅆ" -> "ㅅㅅ";
+        case "ㅉ" -> "ㅈㅈ";
+        default -> chosung;
+    };
   }
 
   public String jungsungTokenizer(String source) {

--- a/src/main/java/com/example/booksearching/elasticsearch/analysis/HangulJamoMorphTokenizer.java
+++ b/src/main/java/com/example/booksearching/elasticsearch/analysis/HangulJamoMorphTokenizer.java
@@ -84,9 +84,15 @@ public class HangulJamoMorphTokenizer {
       case "JONGSUNG" -> jongsungTokenizer(source);
       case "KORTOENG" -> convertKoreanToEnglish(source);
       default -> jamoTokenizer(source);
+    // 한글을 포함하지 않았다면, tokenizing에서 제외
+    if (!containsKorean(source)) {
+      return null;
+    }
     };
 
     return jamo;
+  private boolean containsKorean(String text) {
+    return text != null && text.matches(".*[ㄱ-ㅎㅏ-ㅣ가-힣]+.*");
   }
 
   public String jamoTokenizer(String source) {


### PR DESCRIPTION
# 변경된 사항
- HangulJamoMorphTokenizer가 한글을 포함한 source만 변환하여 반환하게 변경 (이외는 `null`을 반환)
  - `null`이 반환된 경우, Elasticsearch에서 해당 필드가 저장되지 않음 (검색 대상에서 제외)
- HangulJamoMorphTokenizer 리팩토링
  - 사용하지 않는 변수 주석 처리
  - Java 17에서 추가된 Pattern Matching을 이용하여 코드를 더 간결하게 표현
  - 정의해두고 사용하지 않던 HanguelJamoType를 활용하여 가독성, 재사용성을 확보
- DataBaseIndexingApplication 수정
  - HangulJamoMorphTokenizer 변경사항을 적용
  - 메서드명을 직관적으로 수정
  - 로그를 추가 및 수정하여 런타임에 진행 상황을 확인하기 쉽게 변경

## 수정된 파일
- f539ccf7edab2af88de0c3c6a19a57e8111b2283, ab1dce4bb7fc6f8163e2ff89adf30b0a85392d52
  - src/main/java/com/example/booksearching/elasticsearch/analysis/HangulJamoMorphTokenizer.java
- 1a3cbb6bfdc98494295a3d5797ba0c4a8d817af3, 0156dc57763489f97b771a5377fa7ff1cbd29040, ee4b8ed78ac251de825dc0f2784e92b12dfd1854
  - src/main/java/com/example/booksearching/elasticsearch/DataBaseIndexingApplication.java
 
### 관련 이슈
- closes #15 
- closes #12 
- #30
