### PR TITLE
#44 - Toss payments test API를 이용해 간단 구매 기능을 구매 버튼에 연동하기(Server)

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -25,6 +25,7 @@ dependencies {
     implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
     implementation 'org.springframework.boot:spring-boot-starter-thymeleaf'
     implementation 'org.springframework.boot:spring-boot-starter-web'
+    implementation 'org.springframework.boot:spring-boot-starter-webflux'   // WebClient를 사용하기 위해 추가
     implementation 'org.hibernate.validator:hibernate-validator'
     // https://www.elastic.co/guide/en/elasticsearch/client/java-api-client/current/getting-started-java.html
     implementation 'co.elastic.clients:elasticsearch-java:8.11.1'

--- a/src/main/java/com/example/booksearching/spring/controller/PaymentController.java
+++ b/src/main/java/com/example/booksearching/spring/controller/PaymentController.java
@@ -1,0 +1,32 @@
+package com.example.booksearching.spring.controller;
+
+import com.example.booksearching.spring.dto.PaymentCheckRequest;
+import com.example.booksearching.spring.dto.PaymentConfirmRequest;
+import com.example.booksearching.spring.dto.PaymentConfirmResponse;
+import com.example.booksearching.spring.dto.PaymentFailRequest;
+import com.example.booksearching.spring.service.PaymentService;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.http.ResponseEntity;
+import org.springframework.stereotype.Controller;
+import org.springframework.ui.Model;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+
+@Slf4j
+@RequiredArgsConstructor
+@RequestMapping("/payment")
+@Controller
+public class PaymentController {
+
+    private final PaymentService paymentService;
+
+    @GetMapping("/checkout-success")
+    public String paymentRequest(PaymentCheckRequest paymentCheckRequest) {
+        paymentService.createPaymentInfo(paymentCheckRequest);
+
+        return "/checkout-success";
+    }
+}

--- a/src/main/java/com/example/booksearching/spring/controller/PaymentController.java
+++ b/src/main/java/com/example/booksearching/spring/controller/PaymentController.java
@@ -29,4 +29,13 @@ public class PaymentController {
 
         return "/checkout-success";
     }
+
+
+    @GetMapping("/checkout-fail")
+    public String failPayment(PaymentFailRequest paymentFailRequest, Model model) {
+        model.addAttribute("code", paymentFailRequest.code());
+        model.addAttribute("message", paymentFailRequest.message());
+
+        return "/checkout-fail";
+    }
 }

--- a/src/main/java/com/example/booksearching/spring/controller/PaymentController.java
+++ b/src/main/java/com/example/booksearching/spring/controller/PaymentController.java
@@ -23,6 +23,13 @@ public class PaymentController {
 
     private final PaymentService paymentService;
 
+    @PostMapping(value = "/confirm")
+    public ResponseEntity<PaymentConfirmResponse> confirmPayment(@RequestBody PaymentConfirmRequest paymentConfirmRequest) throws Exception {
+        ResponseEntity<PaymentConfirmResponse> res = paymentService.confirmPayment(paymentConfirmRequest);
+
+        return ResponseEntity.status(res.getStatusCode()).body(res.getBody());
+    }
+
     @GetMapping("/checkout-success")
     public String paymentRequest(PaymentCheckRequest paymentCheckRequest) {
         paymentService.createPaymentInfo(paymentCheckRequest);

--- a/src/main/java/com/example/booksearching/spring/dto/PaymentCheckRequest.java
+++ b/src/main/java/com/example/booksearching/spring/dto/PaymentCheckRequest.java
@@ -1,0 +1,11 @@
+package com.example.booksearching.spring.dto;
+
+import com.example.booksearching.spring.entity.constant.PaymentType;
+
+public record PaymentCheckRequest(
+        PaymentType paymentType,
+        String orderId,
+        String paymentKey,
+        Integer amount
+) {
+}

--- a/src/main/java/com/example/booksearching/spring/dto/PaymentConfirmRequest.java
+++ b/src/main/java/com/example/booksearching/spring/dto/PaymentConfirmRequest.java
@@ -1,0 +1,13 @@
+package com.example.booksearching.spring.dto;
+
+public record PaymentConfirmRequest(
+        String paymentKey,
+        String orderId,
+        Integer amount,
+        Item[] items
+) {
+    public record Item(
+            String id,
+            Integer quantity
+    ) { }
+}

--- a/src/main/java/com/example/booksearching/spring/dto/PaymentConfirmResponse.java
+++ b/src/main/java/com/example/booksearching/spring/dto/PaymentConfirmResponse.java
@@ -1,0 +1,362 @@
+package com.example.booksearching.spring.dto;
+
+import com.example.booksearching.spring.entity.constant.PaymentStatus;
+import com.example.booksearching.spring.entity.constant.PaymentType;
+import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.PositiveOrZero;
+import jakarta.validation.constraints.Size;
+
+import java.time.ZonedDateTime;
+
+// https://docs.tosspayments.com/reference#%EA%B2%B0%EC%A0%9C
+// Version 2022-11-16
+public record PaymentConfirmResponse (
+        @NotNull
+        String version,
+        @NotNull
+        @Size(max = 255)
+        String paymentKey,
+        @NotNull
+        PaymentType type,
+        @NotNull
+        @Size(min = 6, max = 64)
+        String orderId,
+        @NotNull
+        @Size(max = 100)
+        String orderName,
+        @NotNull
+        @Size(max = 14)
+        String mId,
+        @NotNull
+        String currency,
+        @NotNull
+        Method method,
+        @NotNull
+        @PositiveOrZero
+        int totalAmount,
+        @NotNull
+        @PositiveOrZero
+        int balanceAmount,
+        @NotNull
+        PaymentStatus status,
+        @NotNull
+        ZonedDateTime requestedAt,
+        @NotNull
+        ZonedDateTime approvedAt,
+        @NotNull
+        boolean useEscrow,
+        @Size(max = 64)
+        String lastTransactionKey,
+        @NotNull
+        @PositiveOrZero
+        int suppliedAmount,
+        @NotNull
+        @PositiveOrZero
+        int vat,
+        @NotNull
+        boolean cultureExpense,
+        @NotNull
+        @PositiveOrZero
+        int taxFreeAmount,
+        @NotNull
+        @PositiveOrZero
+        int taxExemptionAmount,
+        Cancels cancels,
+        @NotNull
+        boolean isPartialCancelable,
+        Card card,
+        VirtualAccount virtualAccount,
+        @Size(max = 50)
+        String secret,
+        MobilePhone mobilePhone,
+        GiftCertificate giftCertificate,
+        Transfer transfer,
+        Receipt receipt,
+        Checkout checkout,
+        EasyPay easyPay,
+        @NotNull
+        @Size(min = 2, max = 2)
+        String country,
+        Failure failure,
+        CashReceipt cashReceipt,
+        CashReceipts[] cashReceipts,
+        Discount discount
+) {
+    public record Cancels (
+            @NotNull
+            @PositiveOrZero
+            int cancelAmount,
+            @NotNull
+            @Size(max = 200)
+            String cancelReason,
+            @NotNull
+            @PositiveOrZero
+            int taxFreeAmount,
+            @NotNull
+            @PositiveOrZero
+            int taxExemptionAmount,
+            @NotNull
+            @PositiveOrZero
+            int refundableAmount,
+            @NotNull
+            @PositiveOrZero
+            int easyPayDiscountAmount,
+            @NotNull
+            ZonedDateTime canceledAt,
+            @NotNull
+            @Size(max = 64)
+            String transactionKey,
+            @Size(max = 200)
+            String receiptKey
+    ) { }
+
+    public record Card (
+            @NotNull
+            @PositiveOrZero
+            int amount,
+            @NotNull
+            String issuerCode,
+            String acquirerCode,
+            @NotNull
+            @Size(max = 20)
+            String number,
+            @NotNull
+            @PositiveOrZero
+            int installmentPlanMonths,
+            @NotNull
+            @Size(max = 8)
+            String approveNo,
+            @NotNull
+            boolean useCardPoint,
+            @NotNull
+            CardType cardType,
+            @NotNull
+            OwnerType ownerType,
+            @NotNull
+            AcquireStatus acquireStatus,
+            @NotNull
+            boolean isInterestFree,
+            InterestPayer interestPayer
+    ) {
+        public enum CardType {
+            신용,
+            체크,
+            기프트,
+            미확인
+        }
+
+        public enum OwnerType {
+            개인,
+            법인,
+            미확인
+        }
+
+        public enum AcquireStatus {
+            READY,
+            REQUESTED,
+            COMPLETED,
+            CANCEL_REQUESTED,
+            CANCELED
+        }
+
+        public enum InterestPayer {
+            BUYER,
+            CARD_COMPANY,
+            MERCHANT
+        }
+    }
+
+    public record VirtualAccount (
+            @NotNull
+            AccountType accountType,
+            @NotNull
+            @Size(max = 20)
+            String accountNumber,
+            @NotNull
+            String bankCode,
+            @NotNull
+            @Size(max = 100)
+            String customerName,
+            @NotNull
+            ZonedDateTime dueDate,
+            @NotNull
+            RefundStatus refundStatus,
+            @NotNull
+            boolean expired,
+            @NotNull
+            SettlementStatus settlementStatus,
+            @NotNull
+            RefundReceiveAccount refundReceiveAccount
+    ) {
+        public record RefundReceiveAccount (
+                @NotNull
+                String bankCode,
+                @NotNull
+                String accountNumber,
+                @NotNull
+                String holderName
+        ) { }
+
+        public enum AccountType {
+            일반,
+            고정
+        }
+
+        public enum RefundStatus {
+            NONE,
+            PENDING,
+            FAILED,
+            PARTIAL_FAILED,
+            COMPLETED
+        }
+    }
+
+    public record MobilePhone (
+            @NotNull
+            String customerMobilePhone,
+            @NotNull
+            SettlementStatus settlementStatus,
+            @NotNull
+            String receiptUrl
+    ) { }
+
+    public record GiftCertificate (
+            @NotNull
+            @Size(max = 8)
+            String approveNo,
+            @NotNull
+            SettlementStatus settlementStatus
+    ) { }
+
+    public record Transfer (
+            @NotNull
+            String bankCode,
+            @NotNull
+            SettlementStatus settlementStatus
+    ) { }
+
+    public record Receipt (
+            @NotNull
+            String url
+    ) { }
+
+    public record Checkout (
+            @NotNull
+            String url
+    ) { }
+
+    public record EasyPay (
+            @NotNull
+            String provider,
+            @NotNull
+            @PositiveOrZero
+            int amount,
+            @NotNull
+            @PositiveOrZero
+            int discountAmount
+    ) { }
+
+    public record Failure (
+            @NotNull
+            String code,
+            @NotNull
+            @Size(max = 510)
+            String message
+    ) { }
+
+    public record CashReceipt (
+            @NotNull
+            CashReceiptType type,
+            @NotNull
+            @Size(max = 200)
+            String receiptKey,
+            @NotNull
+            @Size(max = 9)
+            String issueNumber,
+            @NotNull
+            String receiptUrl,
+            @NotNull
+            @PositiveOrZero
+            int amount,
+            @NotNull
+            @PositiveOrZero
+            int taxFreeAmount
+    ) { }
+
+    public record CashReceipts (
+            @NotNull
+            @Size(max = 200)
+            String receiptKey,
+            @NotNull
+            @Size(min = 6, max = 64)
+            String orderId,
+            @NotNull
+            @Size(max = 100)
+            String orderName,
+            @NotNull
+            CashReceiptType type,
+            @NotNull
+            @Size(max = 9)
+            String issueNumber,
+            @NotNull
+            String receiptUrl,
+            @NotNull
+            @Size(max = 10)
+            String businessNumber,
+            @NotNull
+            TransactionType transactionType,
+            @NotNull
+            @PositiveOrZero
+            int amount,
+            @NotNull
+            @PositiveOrZero
+            int taxFreeAmount,
+            @NotNull
+            IssueStatus issueStatus,
+            @NotNull
+            Failure failure,
+            @NotNull
+            @Size(max = 30)
+            String customerIdentityNumber,
+            @NotNull
+            ZonedDateTime requestedAt
+    ) {
+        public enum TransactionType {
+            CONFIRM,
+            CANCEL
+        }
+
+        public enum IssueStatus {
+            IN_PROGRESS,
+            COMPLETED,
+            FAILED
+        }
+    }
+
+    public record Discount (
+            @NotNull
+            @PositiveOrZero
+            int amount
+    ) { }
+
+    public enum Method {
+        카드,
+        가상계좌,
+        간편결제,
+        휴대폰,
+        계좌이체,
+        문화상품권,
+        도서문화상품권,
+        게임문화상품권
+    }
+
+    public enum SettlementStatus {
+        INCOMPLETED,
+        COMPLETED
+    }
+
+    public enum CashReceiptType {
+        소득공제,
+        지출증빙
+    }
+}

--- a/src/main/java/com/example/booksearching/spring/dto/PaymentFailRequest.java
+++ b/src/main/java/com/example/booksearching/spring/dto/PaymentFailRequest.java
@@ -1,0 +1,10 @@
+package com.example.booksearching.spring.dto;
+
+import com.example.booksearching.spring.entity.constant.PaymentErrorCode;
+
+public record PaymentFailRequest(
+    PaymentErrorCode code,
+    String message,
+    String orderId
+) {
+}

--- a/src/main/java/com/example/booksearching/spring/entity/constant/PaymentErrorCode.java
+++ b/src/main/java/com/example/booksearching/spring/entity/constant/PaymentErrorCode.java
@@ -1,0 +1,14 @@
+package com.example.booksearching.spring.entity.constant;
+
+public enum PaymentErrorCode {
+    PAY_PROCESS_CANCELED("구매자에 의해 결제가 취소되었습니다."),
+    PAY_PROCESS_ABORTED("결제 진행 중 승인에 실패하여 결제가 중단되었습니다."),
+    REJECT_CARD_COMPANY("카드사에 결제 승인이 거절되었습니다."),
+    NOT_FOUND_PAYMENT_SESSION("결제 승인 요청에서 문제가 발생했습니다."),
+    FORBIDDEN_REQUEST("요청 정보가 변경되었습니다."),
+    UNAUTHORIZED_KEY("잘못된 API 키 입니다.");
+
+    private final String type;
+
+    PaymentErrorCode(String type) { this.type = type; }
+}

--- a/src/main/java/com/example/booksearching/spring/exception/PaymentException.java
+++ b/src/main/java/com/example/booksearching/spring/exception/PaymentException.java
@@ -1,0 +1,14 @@
+package com.example.booksearching.spring.exception;
+
+import lombok.RequiredArgsConstructor;
+
+@RequiredArgsConstructor
+public class PaymentException extends CustomException {
+
+    private final PaymentExceptionType paymentExceptionType;
+
+    @Override
+    public CustomExceptionType getCustomExceptionType() {
+        return paymentExceptionType;
+    }
+}

--- a/src/main/java/com/example/booksearching/spring/exception/PaymentExceptionType.java
+++ b/src/main/java/com/example/booksearching/spring/exception/PaymentExceptionType.java
@@ -1,0 +1,23 @@
+package com.example.booksearching.spring.exception;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+
+@RequiredArgsConstructor
+public enum PaymentExceptionType implements CustomExceptionType {
+
+    PAYMENT_MISMATCH_EXCEPTION(HttpStatus.INTERNAL_SERVER_ERROR, "결제 정보가 일치하지 않습니다."),
+    PAYMENT_CONFIRM_FAIL(HttpStatus.INTERNAL_SERVER_ERROR, "결제 승인에 실패했습니다.");
+
+    private final HttpStatus httpStatus;
+    private final String errorMsg;
+
+    @Override
+    public HttpStatus getHttpStatus() {
+        return httpStatus;
+    }
+    @Override
+    public String getErrorMsg() {
+        return errorMsg;
+    }
+}

--- a/src/main/java/com/example/booksearching/spring/exception/TossException.java
+++ b/src/main/java/com/example/booksearching/spring/exception/TossException.java
@@ -1,0 +1,14 @@
+package com.example.booksearching.spring.exception;
+
+import lombok.RequiredArgsConstructor;
+
+@RequiredArgsConstructor
+public class TossException extends CustomException {
+
+    private final TossExceptionType tossExceptionType;
+
+    @Override
+    public CustomExceptionType getCustomExceptionType() {
+        return tossExceptionType;
+    }
+}

--- a/src/main/java/com/example/booksearching/spring/exception/TossExceptionType.java
+++ b/src/main/java/com/example/booksearching/spring/exception/TossExceptionType.java
@@ -1,0 +1,22 @@
+package com.example.booksearching.spring.exception;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+
+@RequiredArgsConstructor
+public enum TossExceptionType implements CustomExceptionType {
+
+    TOSS_CONFIRM_FAIL(HttpStatus.INTERNAL_SERVER_ERROR, "Toss 결제 최종 승인 요청이 실패했습니다.");
+
+    private final HttpStatus httpStatus;
+    private final String errorMsg;
+
+    @Override
+    public HttpStatus getHttpStatus() {
+        return httpStatus;
+    }
+    @Override
+    public String getErrorMsg() {
+        return errorMsg;
+    }
+}

--- a/src/main/java/com/example/booksearching/spring/service/PaymentService.java
+++ b/src/main/java/com/example/booksearching/spring/service/PaymentService.java
@@ -1,0 +1,64 @@
+package com.example.booksearching.spring.service;
+
+import com.example.booksearching.spring.dto.PaymentCheckRequest;
+import com.example.booksearching.spring.dto.PaymentConfirmRequest;
+import com.example.booksearching.spring.dto.PaymentConfirmResponse;
+import com.example.booksearching.spring.entity.Book;
+import com.example.booksearching.spring.entity.Orders;
+import com.example.booksearching.spring.entity.OrdersDetail;
+import com.example.booksearching.spring.entity.Payment;
+import com.example.booksearching.spring.entity.constant.OrderStatus;
+import com.example.booksearching.spring.entity.constant.PaymentStatus;
+import com.example.booksearching.spring.exception.PaymentException;
+import com.example.booksearching.spring.exception.PaymentExceptionType;
+import com.example.booksearching.spring.exception.TossException;
+import com.example.booksearching.spring.exception.TossExceptionType;
+import com.example.booksearching.spring.repository.BookRepository;
+import com.example.booksearching.spring.repository.OrderDetailRepository;
+import com.example.booksearching.spring.repository.OrderRepository;
+import com.example.booksearching.spring.repository.PaymentRepository;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.MediaType;
+import org.springframework.http.ResponseEntity;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+import org.springframework.web.reactive.function.client.WebClient;
+
+import java.nio.charset.StandardCharsets;
+import java.util.Arrays;
+import java.util.Base64;
+
+@Slf4j
+@RequiredArgsConstructor
+@Transactional
+@Service
+public class PaymentService {
+
+    private final BookRepository bookRepository;
+    private final OrderDetailRepository orderDetailRepository;
+    private final OrderRepository orderRepository;
+    private final PaymentRepository paymentRepository;
+
+    public void createPaymentInfo(PaymentCheckRequest paymentCheckRequest) {
+        Payment payment = Payment.of(
+                paymentCheckRequest.paymentKey(),
+                paymentCheckRequest.amount(),
+                paymentCheckRequest.paymentType(),
+                PaymentStatus.READY
+        );
+
+        Orders order = Orders.of(
+                paymentCheckRequest.orderId(),
+                paymentCheckRequest.amount(),
+                OrderStatus.READY,
+                payment,
+                null
+        );
+
+        paymentRepository.save(payment);
+        orderRepository.save(order);
+    }
+}

--- a/src/main/resources/application.yaml
+++ b/src/main/resources/application.yaml
@@ -26,3 +26,6 @@ elasticsearch:
   password: change me
   encodedApiKey: change me
   fingerprint: change me
+
+toss:
+  api-key: change me


### PR DESCRIPTION
# 변경 이유
- Toss test API를 이용해 구매 기능을 추가

# 변경된 사항
- #44 와 [Toss 결제 연동하기](https://docs.tosspayments.com/guides/payment-widget/integration)에서 확인 할 수 있는 결제 flow 중, `Server`에서 처리하는 부분의 코드를 작성
- 결제 성공/실패/승인에 대한 `Controller`와 `Service`를 구현
  - 관련 예외 구현
  - 관련 `DTO` 구현
-  `WebClient`를 이용해 외부 API에 요청
  - `RestTemplate`를 써도 되지만 fluent API를 사용하고 싶었음
  - [해당 블로그](https://mangkyu.tistory.com/303)에 의하면 Spring boot 3.2 버전부터 [`RestTemplate 스펙 문서`](https://docs.spring.io/spring-framework/docs/current/javadoc-api/org/springframework/web/client/RestTemplate.html)에서 언급되는 동기적 HTTP 접근에 더 모던한 API인 `RestClient`를 제공한다하니 Spring boot 버전 업 할 때 변경을 고려 (현재 버전 3.1.2)

## 추가된 파일
- a416103e, 0f8d94b, 580011b
    - src/main/java/com/example/booksearching/spring/controller/PaymentController.java
- a416103e, 580011b
  -  src/main/java/com/example/booksearching/spring/service/PaymentService.java
- a416103e
    - src/main/java/com/example/booksearching/spring/dto/PaymentCheckRequest.java
- 0f8d94b
  - src/main/java/com/example/booksearching/spring/dto/PaymentFailRequest.java
  - src/main/java/com/example/booksearching/spring/entity/constant/PaymentErrorCode.java
- 580011b
  - src/main/java/com/example/booksearching/spring/dto/PaymentConfirmRequest.java
  - src/main/java/com/example/booksearching/spring/dto/PaymentConfirmResponse.java
  - src/main/java/com/example/booksearching/spring/exception/PaymentException.java
  - src/main/java/com/example/booksearching/spring/exception/PaymentExceptionType.java
  - src/main/java/com/example/booksearching/spring/exception/TossException.java
  - src/main/java/com/example/booksearching/spring/exception/TossExceptionType.java

## 수정된 파일
- a416103e
    - src/main/resources/application.yaml
- 580011b
    - build.gradle

### 관련 이슈
- #44
