### PR TITLE
#47 - DB 잘못된 설계 핫픽스

### DIFF
--- a/src/main/java/com/example/booksearching/spring/entity/OrdersDetail.java
+++ b/src/main/java/com/example/booksearching/spring/entity/OrdersDetail.java
@@ -1,6 +1,9 @@
 package com.example.booksearching.spring.entity;
 
-import jakarta.persistence.*;
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.Id;
+import jakarta.persistence.ManyToOne;
 import jakarta.validation.constraints.Positive;
 import jakarta.validation.constraints.PositiveOrZero;
 import jakarta.validation.constraints.Size;
@@ -24,7 +27,7 @@ public class OrdersDetail {
     @Column(nullable = false)
     private Integer amount;
 
-    @OneToOne
+    @ManyToOne
     private Book book;
 
     @ManyToOne


### PR DESCRIPTION
# 변경 이유
- 동일한 `Book`이 여러 `OrdersDetail`과 관계를 맺을 수 있으니 1:N 관계로 해야함

# 변경된 사항
- `OrdersDetail` 엔티티에서 `Book`관의 관계가 `@OneToOne`에서 `@ManyToOne`로 변경

![image](https://github.com/sGOM/book-searching/assets/29831584/e6d7a06e-3d4c-434e-962d-4c6e304c9d27)

## 수정된 파일
- 02aaf5e59b453b2c84212864e7b43157cb9e497c
    - src/main/java/com/example/booksearching/spring/entity/OrdersDetail.java

### 관련 이슈
- closes #47 
