### PR TITLE
Feat/#61 - Spring Security 추가 (ID/Password, Jwt 두가지 방식)

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -1,7 +1,7 @@
 plugins {
     id 'java'
-    id 'org.springframework.boot' version '3.1.2'
-    id 'io.spring.dependency-management' version '1.1.2'
+    id 'org.springframework.boot' version '3.2.3'
+    id 'io.spring.dependency-management' version '1.1.4'
 }
 
 group = 'com.example'
@@ -26,10 +26,13 @@ dependencies {
     implementation 'org.springframework.boot:spring-boot-starter-thymeleaf'
     implementation 'org.springframework.boot:spring-boot-starter-web'
     implementation 'org.springframework.boot:spring-boot-starter-webflux'   // WebClient를 사용하기 위해 추가
+    implementation 'org.springframework.boot:spring-boot-starter-security'
+    implementation 'org.springframework.security:spring-security-oauth2-jose'   // JwtDecoder를 사용하기 위해 추가
+    implementation 'org.springframework.security:spring-security-oauth2-resource-server'
     implementation 'org.hibernate.validator:hibernate-validator'
     // https://www.elastic.co/guide/en/elasticsearch/client/java-api-client/current/getting-started-java.html
     implementation 'co.elastic.clients:elasticsearch-java:8.11.1'
-    implementation 'com.fasterxml.jackson.core:jackson-databind:2.12.7.1'
+    implementation 'com.fasterxml.jackson.core:jackson-databind'
     compileOnly 'org.projectlombok:lombok'
     runtimeOnly 'com.mysql:mysql-connector-j'
     annotationProcessor 'org.projectlombok:lombok'

--- a/src/main/java/com/example/booksearching/spring/config/JwtConfig.java
+++ b/src/main/java/com/example/booksearching/spring/config/JwtConfig.java
@@ -1,0 +1,48 @@
+package com.example.booksearching.spring.config;
+
+import com.nimbusds.jose.JWSAlgorithm;
+import com.nimbusds.jose.jwk.JWK;
+import com.nimbusds.jose.jwk.JWKSet;
+import com.nimbusds.jose.jwk.OctetSequenceKey;
+import com.nimbusds.jose.jwk.source.ImmutableJWKSet;
+import com.nimbusds.jose.jwk.source.JWKSource;
+import com.nimbusds.jose.proc.SecurityContext;
+import com.nimbusds.jose.util.StandardCharset;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.security.oauth2.jose.jws.MacAlgorithm;
+import org.springframework.security.oauth2.jwt.JwtDecoder;
+import org.springframework.security.oauth2.jwt.JwtEncoder;
+import org.springframework.security.oauth2.jwt.NimbusJwtDecoder;
+import org.springframework.security.oauth2.jwt.NimbusJwtEncoder;
+
+import javax.crypto.SecretKey;
+import javax.crypto.spec.SecretKeySpec;
+
+@Configuration
+public class JwtConfig {
+
+    @Value("${jwt.secret-key}")
+    private String secretKey;
+
+    @Bean
+    public JwtDecoder jwtDecoder() {
+        SecretKey sk = new SecretKeySpec(secretKey.getBytes(StandardCharset.UTF_8), MacAlgorithm.HS256.getName());
+        return NimbusJwtDecoder.withSecretKey(sk).build();
+    }
+
+    @Bean
+    public JwtEncoder jwtEncoder() {
+        // Create JWK
+        JWK jwk = new OctetSequenceKey.Builder(secretKey.getBytes(StandardCharset.UTF_8))
+                .algorithm(JWSAlgorithm.HS256)
+                .build();
+        // Create JWKSource
+        JWKSource<SecurityContext> jwkSource = new ImmutableJWKSet<>(new JWKSet(jwk));
+
+        // Create JwtEncoder
+        return new NimbusJwtEncoder(jwkSource);
+    }
+
+}

--- a/src/main/java/com/example/booksearching/spring/config/WebSecurityConfig.java
+++ b/src/main/java/com/example/booksearching/spring/config/WebSecurityConfig.java
@@ -1,0 +1,77 @@
+package com.example.booksearching.spring.config;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.boot.autoconfigure.security.servlet.PathRequest;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.http.HttpMethod;
+import org.springframework.security.access.expression.method.DefaultMethodSecurityExpressionHandler;
+import org.springframework.security.access.expression.method.MethodSecurityExpressionHandler;
+import org.springframework.security.access.hierarchicalroles.RoleHierarchy;
+import org.springframework.security.access.hierarchicalroles.RoleHierarchyImpl;
+import org.springframework.security.config.Customizer;
+import org.springframework.security.config.annotation.web.builders.HttpSecurity;
+import org.springframework.security.config.annotation.web.configurers.AbstractHttpConfigurer;
+import org.springframework.security.config.annotation.web.configurers.HeadersConfigurer;
+import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
+import org.springframework.security.crypto.password.PasswordEncoder;
+import org.springframework.security.web.SecurityFilterChain;
+import org.springframework.security.web.util.matcher.AntPathRequestMatcher;
+import org.springframework.security.web.util.matcher.NegatedRequestMatcher;
+import org.springframework.security.web.util.matcher.OrRequestMatcher;
+import org.springframework.security.web.util.matcher.RequestMatcher;
+
+import static com.example.booksearching.spring.security.authentication.SecurityConstants.*;
+
+@RequiredArgsConstructor
+@Configuration
+public class WebSecurityConfig {
+
+
+    @Bean
+    public SecurityFilterChain securityFilterChain(HttpSecurity http) throws Exception {
+        http
+                .formLogin(AbstractHttpConfigurer::disable)
+                .httpBasic(AbstractHttpConfigurer::disable)
+                .csrf(AbstractHttpConfigurer::disable)
+                .headers(headers -> headers.frameOptions(HeadersConfigurer.FrameOptionsConfig::sameOrigin))
+                .authorizeHttpRequests(authorize -> authorize
+                        .requestMatchers(PathRequest.toStaticResources().atCommonLocations()).permitAll()
+                        .requestMatchers(getAuthorityNotRequiredUrl()).permitAll()
+                        .anyRequest().authenticated()
+                );
+
+        return http.build();
+    }
+
+    private RequestMatcher getAuthorityNotRequiredUrl() {
+        return new OrRequestMatcher(
+                new AntPathRequestMatcher(ROOT_URL),
+                new AntPathRequestMatcher(SECURITY_ERROR_URL),
+                new AntPathRequestMatcher(SIGN_IN_API_URL, HttpMethod.POST.toString()),
+                new AntPathRequestMatcher(SIGN_UP_API_URL, HttpMethod.POST.toString()),
+                new AntPathRequestMatcher("/search/**"),
+                new AntPathRequestMatcher("/api/search/**")
+        );
+    }
+
+    @Bean
+    public PasswordEncoder passwordEncoder() {
+        return new BCryptPasswordEncoder();
+    }
+
+    @Bean
+    static RoleHierarchy roleHierarchy() {
+        RoleHierarchyImpl hierarchy = new RoleHierarchyImpl();
+        hierarchy.setHierarchy("ROLE_ADMIN > ROLE_USER");
+        return hierarchy;
+    }
+
+    @Bean
+    static MethodSecurityExpressionHandler methodSecurityExpressionHandler(RoleHierarchy roleHierarchy) {
+        DefaultMethodSecurityExpressionHandler expressionHandler = new DefaultMethodSecurityExpressionHandler();
+        expressionHandler.setRoleHierarchy(roleHierarchy);
+        return expressionHandler;
+    }
+
+}

--- a/src/main/java/com/example/booksearching/spring/config/WebSecurityConfig.java
+++ b/src/main/java/com/example/booksearching/spring/config/WebSecurityConfig.java
@@ -1,5 +1,6 @@
 package com.example.booksearching.spring.config;
 
+import com.example.booksearching.spring.security.authentication.dao.CustomDaoAuthenticationConfigurer;
 import lombok.RequiredArgsConstructor;
 import org.springframework.boot.autoconfigure.security.servlet.PathRequest;
 import org.springframework.context.annotation.Bean;
@@ -39,9 +40,17 @@ public class WebSecurityConfig {
                         .requestMatchers(PathRequest.toStaticResources().atCommonLocations()).permitAll()
                         .requestMatchers(getAuthorityNotRequiredUrl()).permitAll()
                         .anyRequest().authenticated()
+                )
+                .with(
+                        customDaoAuthenticationConfig(),
+                        Customizer.withDefaults()
                 );
 
         return http.build();
+    }
+
+    private CustomDaoAuthenticationConfigurer customDaoAuthenticationConfig() {
+        return new CustomDaoAuthenticationConfigurer();
     }
 
     private RequestMatcher getAuthorityNotRequiredUrl() {

--- a/src/main/java/com/example/booksearching/spring/controller/api/PaymentApiController.java
+++ b/src/main/java/com/example/booksearching/spring/controller/api/PaymentApiController.java
@@ -1,0 +1,27 @@
+package com.example.booksearching.spring.controller.api;
+
+import com.example.booksearching.spring.dto.PaymentConfirmRequest;
+import com.example.booksearching.spring.dto.PaymentConfirmResponse;
+import com.example.booksearching.spring.service.PaymentService;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@Slf4j
+@RequiredArgsConstructor
+@RequestMapping("/api/payment")
+@RestController
+public class PaymentApiController {
+
+    private final PaymentService paymentService;
+
+    @PostMapping("/confirm")
+    public ResponseEntity<PaymentConfirmResponse> confirmPayment(@RequestBody PaymentConfirmRequest paymentConfirmRequest) {
+        return paymentService.confirmPayment(paymentConfirmRequest);
+    }
+
+}

--- a/src/main/java/com/example/booksearching/spring/controller/api/SearchApiController.java
+++ b/src/main/java/com/example/booksearching/spring/controller/api/SearchApiController.java
@@ -1,37 +1,22 @@
-package com.example.booksearching.spring.controller;
+package com.example.booksearching.spring.controller.api;
 
 import com.example.booksearching.spring.dto.BookInfoResponse;
 import com.example.booksearching.spring.service.SearchService;
-import jakarta.validation.constraints.Positive;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
-import org.springframework.stereotype.Controller;
-import org.springframework.ui.Model;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
 
 import java.util.List;
 
 @RequiredArgsConstructor
-@RequestMapping("/search")
-@Controller
-public class SearchController {
+@RequestMapping("/api/search")
+@RestController
+public class SearchApiController {
 
     private final SearchService searchService;
-
-    @GetMapping
-    public String getSearch(
-            String keyword,
-            @Positive @RequestParam(defaultValue = "1", required = false) int page,
-            @Positive @RequestParam(defaultValue = "24", required = false) int size,
-            Model map
-    ) {
-        map.addAttribute("data", searchService.searchBooks(keyword, page, size));
-
-        return "index";
-    }
 
     @GetMapping("/auto-complete")
     public ResponseEntity<List<BookInfoResponse>> getAutocompleteSuggestions(String keyword) {

--- a/src/main/java/com/example/booksearching/spring/controller/web/HomePageController.java
+++ b/src/main/java/com/example/booksearching/spring/controller/web/HomePageController.java
@@ -1,10 +1,10 @@
-package com.example.booksearching.spring.controller;
+package com.example.booksearching.spring.controller.web;
 
 import org.springframework.stereotype.Controller;
 import org.springframework.web.bind.annotation.GetMapping;
 
 @Controller
-public class MainController {
+public class HomePageController {
 
     @GetMapping("/")
     public String root() {

--- a/src/main/java/com/example/booksearching/spring/controller/web/PaymentPageController.java
+++ b/src/main/java/com/example/booksearching/spring/controller/web/PaymentPageController.java
@@ -1,32 +1,22 @@
-package com.example.booksearching.spring.controller;
+package com.example.booksearching.spring.controller.web;
 
 import com.example.booksearching.spring.dto.PaymentCheckRequest;
-import com.example.booksearching.spring.dto.PaymentConfirmRequest;
-import com.example.booksearching.spring.dto.PaymentConfirmResponse;
 import com.example.booksearching.spring.dto.PaymentFailRequest;
 import com.example.booksearching.spring.service.PaymentService;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
-import org.springframework.http.ResponseEntity;
 import org.springframework.stereotype.Controller;
 import org.springframework.ui.Model;
 import org.springframework.web.bind.annotation.GetMapping;
-import org.springframework.web.bind.annotation.PostMapping;
-import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 
 @Slf4j
 @RequiredArgsConstructor
 @RequestMapping("/payment")
 @Controller
-public class PaymentController {
+public class PaymentPageController {
 
     private final PaymentService paymentService;
-
-    @PostMapping("/confirm")
-    public ResponseEntity<PaymentConfirmResponse> confirmPayment(@RequestBody PaymentConfirmRequest paymentConfirmRequest) {
-        return paymentService.confirmPayment(paymentConfirmRequest);
-    }
 
     @GetMapping("/checkout-success")
     public String paymentRequest(PaymentCheckRequest paymentCheckRequest) {

--- a/src/main/java/com/example/booksearching/spring/controller/web/SearchPageController.java
+++ b/src/main/java/com/example/booksearching/spring/controller/web/SearchPageController.java
@@ -1,0 +1,31 @@
+package com.example.booksearching.spring.controller.web;
+
+import com.example.booksearching.spring.service.SearchService;
+import jakarta.validation.constraints.Positive;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Controller;
+import org.springframework.ui.Model;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+
+@RequiredArgsConstructor
+@RequestMapping("/search")
+@Controller
+public class SearchPageController {
+
+    private final SearchService searchService;
+
+    @GetMapping
+    public String getSearchPage(
+            String keyword,
+            @Positive @RequestParam(defaultValue = "1", required = false) int page,
+            @Positive @RequestParam(defaultValue = "24", required = false) int size,
+            Model map
+    ) {
+        map.addAttribute("data", searchService.searchBooks(keyword, page, size));
+
+        return "index";
+    }
+
+}

--- a/src/main/java/com/example/booksearching/spring/dto/SignInRequest.java
+++ b/src/main/java/com/example/booksearching/spring/dto/SignInRequest.java
@@ -1,0 +1,16 @@
+package com.example.booksearching.spring.dto;
+
+import com.example.booksearching.spring.annotation.ValidPassword;
+import com.example.booksearching.spring.annotation.ValidUsername;
+
+public record SignInRequest(
+
+        @ValidUsername
+        String username,
+
+        @ValidPassword
+        String password
+
+) {
+
+}

--- a/src/main/java/com/example/booksearching/spring/exception/SecurityException.java
+++ b/src/main/java/com/example/booksearching/spring/exception/SecurityException.java
@@ -1,0 +1,15 @@
+package com.example.booksearching.spring.exception;
+
+import lombok.RequiredArgsConstructor;
+
+@RequiredArgsConstructor
+public class SecurityException extends CustomException {
+
+    private final SecurityExceptionType securityExceptionType;
+
+    @Override
+    public CustomExceptionType getCustomExceptionType() {
+        return securityExceptionType;
+    }
+
+}

--- a/src/main/java/com/example/booksearching/spring/exception/SecurityExceptionType.java
+++ b/src/main/java/com/example/booksearching/spring/exception/SecurityExceptionType.java
@@ -1,0 +1,28 @@
+package com.example.booksearching.spring.exception;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+
+@RequiredArgsConstructor
+public enum SecurityExceptionType implements CustomExceptionType {
+
+    DTO_MAPPING_FAIL(HttpStatus.BAD_REQUEST, "올바른 형식의 요청이 아닙니다."),
+    INVALID_USER_INFO(HttpStatus.UNAUTHORIZED, "인증에 실패했습니다. 아이디와 비밀번호를 확인해주세요."),
+    INVALID_TOKEN(HttpStatus.UNAUTHORIZED, "유효하지 않은 토큰입니다.")
+    ;
+
+    private final HttpStatus httpStatus;
+
+    private final String errorMsg;
+
+    @Override
+    public HttpStatus getHttpStatus() {
+        return httpStatus;
+    }
+
+    @Override
+    public String getErrorMsg() {
+        return errorMsg;
+    }
+
+}

--- a/src/main/java/com/example/booksearching/spring/security/UserAccountDetails.java
+++ b/src/main/java/com/example/booksearching/spring/security/UserAccountDetails.java
@@ -1,0 +1,47 @@
+package com.example.booksearching.spring.security;
+
+import com.example.booksearching.spring.entity.UserAccount;
+import org.springframework.security.core.GrantedAuthority;
+import org.springframework.security.core.userdetails.UserDetails;
+
+import java.util.Collection;
+import java.util.Collections;
+
+public record UserAccountDetails(UserAccount userAccount) implements UserDetails {
+
+    @Override
+    public Collection<? extends GrantedAuthority> getAuthorities() {
+        return Collections.singleton(() -> userAccount.getRole().toString());
+    }
+
+    @Override
+    public String getPassword() {
+        return userAccount.getPassword();
+    }
+
+    @Override
+    public String getUsername() {
+        return userAccount.getUsername();
+    }
+
+    @Override
+    public boolean isAccountNonExpired() {
+        return true;
+    }
+
+    @Override
+    public boolean isAccountNonLocked() {
+        return true;
+    }
+
+    @Override
+    public boolean isCredentialsNonExpired() {
+        return true;
+    }
+
+    @Override
+    public boolean isEnabled() {
+        return true;
+    }
+
+}

--- a/src/main/java/com/example/booksearching/spring/security/UserAccountDetailsService.java
+++ b/src/main/java/com/example/booksearching/spring/security/UserAccountDetailsService.java
@@ -1,0 +1,24 @@
+package com.example.booksearching.spring.security;
+
+import com.example.booksearching.spring.entity.UserAccount;
+import com.example.booksearching.spring.repository.UserAccountRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.security.core.userdetails.UserDetails;
+import org.springframework.security.core.userdetails.UserDetailsService;
+import org.springframework.security.core.userdetails.UsernameNotFoundException;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
+public class UserAccountDetailsService implements UserDetailsService {
+
+    private final UserAccountRepository userAccountRepository;
+
+    @Override
+    public UserDetails loadUserByUsername(String username) throws UsernameNotFoundException {
+        UserAccount userAccount = userAccountRepository.findByUsername(username)
+                .orElseThrow(() -> new UsernameNotFoundException("올바르지 않은 아이디입니다."));
+        return new UserAccountDetails(userAccount);
+    }
+
+}

--- a/src/main/java/com/example/booksearching/spring/security/authentication/SecurityConstants.java
+++ b/src/main/java/com/example/booksearching/spring/security/authentication/SecurityConstants.java
@@ -1,0 +1,20 @@
+package com.example.booksearching.spring.security.authentication;
+
+public class SecurityConstants {
+
+    public static final String ROOT_URL = "/";
+    public static final String SIGN_IN_PAGE_URL = "/users/sign-in";
+    public static final String SIGN_UP_PAGE_URL = "/users/sign-up";
+    public static final String SIGN_IN_PAGE_RESOURCE_PATH = "/templates/sign-in.html";
+    public static final String SIGN_UP_PAGE_RESOURCE_PATH = "/templates/sign-up.html";
+    public static final String SIGN_IN_API_URL = "/api/users/sign-in";
+    public static final String SIGN_UP_API_URL = "/api/users/sign-up";
+    public static final String SECURITY_ERROR_URL = "/error/**";
+
+    public static final long ACCESS_TOKEN_EXPIRATION = 1L;   // 1시간
+
+    public static final String ACCESS_TOKEN_HEADER = "Authorization";
+    public static final String BEARER_PREFIX = "Bearer ";
+    public static final int BEARER_PREFIX_LENGTH = BEARER_PREFIX.length();
+
+}

--- a/src/main/java/com/example/booksearching/spring/security/authentication/dao/CustomDaoAuthenticationConfigurer.java
+++ b/src/main/java/com/example/booksearching/spring/security/authentication/dao/CustomDaoAuthenticationConfigurer.java
@@ -1,0 +1,146 @@
+package com.example.booksearching.spring.security.authentication.dao;
+
+import lombok.Getter;
+import org.springframework.beans.factory.NoUniqueBeanDefinitionException;
+import org.springframework.context.ApplicationContext;
+import org.springframework.security.authentication.AuthenticationManager;
+import org.springframework.security.config.annotation.SecurityConfigurerAdapter;
+import org.springframework.security.config.annotation.web.builders.HttpSecurity;
+import org.springframework.security.config.annotation.web.configurers.ExceptionHandlingConfigurer;
+import org.springframework.security.oauth2.jwt.JwtEncoder;
+import org.springframework.security.web.AuthenticationEntryPoint;
+import org.springframework.security.web.DefaultSecurityFilterChain;
+import org.springframework.security.web.authentication.AuthenticationFailureHandler;
+import org.springframework.security.web.authentication.AuthenticationSuccessHandler;
+import org.springframework.security.web.authentication.LoginUrlAuthenticationEntryPoint;
+import org.springframework.security.web.authentication.UsernamePasswordAuthenticationFilter;
+import org.springframework.security.web.util.matcher.AntPathRequestMatcher;
+import org.springframework.util.Assert;
+
+import javax.annotation.Nullable;
+
+import static com.example.booksearching.spring.security.authentication.SecurityConstants.*;
+
+@Getter
+public class CustomDaoAuthenticationConfigurer extends SecurityConfigurerAdapter<DefaultSecurityFilterChain, HttpSecurity> {
+
+    private final CustomDaoAuthenticationFilter customDaoAuthenticationFilter = new CustomDaoAuthenticationFilter(SIGN_IN_API_URL);
+
+    private final CustomSignPageLoadingFilter customSignPageLoadingFilter = new CustomSignPageLoadingFilter(SIGN_IN_PAGE_RESOURCE_PATH, SIGN_IN_PAGE_URL, SIGN_UP_PAGE_RESOURCE_PATH, SIGN_UP_PAGE_URL);
+
+    private AuthenticationSuccessHandler successHandler;
+
+    private AuthenticationEntryPoint authenticationEntryPoint;
+
+    private String signInApiUrl = SIGN_IN_API_URL;
+
+    public CustomDaoAuthenticationConfigurer() {
+        setSignInApiUrl(SIGN_IN_API_URL);
+    }
+
+    public CustomDaoAuthenticationConfigurer successHandler(AuthenticationSuccessHandler successHandler) {
+        Assert.notNull(successHandler, "successHandler must not be null.");
+        this.customDaoAuthenticationFilter.setAuthenticationSuccessHandler(successHandler);
+        return this;
+    }
+
+    public CustomDaoAuthenticationConfigurer failureHandler(AuthenticationFailureHandler failureHandler) {
+        Assert.notNull(failureHandler, "failureHandler must not be null.");
+        this.customDaoAuthenticationFilter.setAuthenticationFailureHandler(failureHandler);
+        return this;
+    }
+
+    public CustomDaoAuthenticationConfigurer signInApiUrl(String signInApiUrl) {
+        Assert.notNull(signInApiUrl, "signInApiUrl must not be null.");
+        setSignInApiUrl(signInApiUrl);
+        return this;
+    }
+
+    public CustomDaoAuthenticationConfigurer signInPageUrl(String signInPageUrl) {
+        Assert.notNull(signInPageUrl, "signInPageUrl must not be null.");
+        this.customSignPageLoadingFilter.setSignInPageUrl(signInPageUrl);
+        return this;
+    }
+
+    public CustomDaoAuthenticationConfigurer signInPageResourcePath(String signInPageResourcePath) {
+        Assert.notNull(signInPageResourcePath, "signInPageResourcePath must not be null.");
+        this.customSignPageLoadingFilter.setSignInPageResourcePath(signInPageResourcePath);
+        return this;
+    }
+
+    public CustomDaoAuthenticationConfigurer signUpPageUrl(@Nullable String signUpPageUrl) {
+        this.customSignPageLoadingFilter.setSignUpPageUrl(signUpPageUrl);
+        return this;
+    }
+
+    public CustomDaoAuthenticationConfigurer signUpPageResourcePath(String signUpPageResourcePath) {
+        Assert.notNull(signUpPageResourcePath, "signInPageResourcePath must not be null.");
+        this.customSignPageLoadingFilter.setSignUpPageResourcePath(signUpPageResourcePath);
+        return this;
+    }
+
+    public CustomDaoAuthenticationConfigurer authenticationEntryPoint(@Nullable AuthenticationEntryPoint authenticationEntryPoint) {
+        this.authenticationEntryPoint = authenticationEntryPoint;
+        return this;
+    }
+
+    @Override
+    public void init(HttpSecurity http) throws Exception {
+        super.init(http);
+        setSuccessHandler(http);
+    }
+
+    @Override
+    public void configure(HttpSecurity http) {
+        AuthenticationManager authenticationManager = http.getSharedObject(AuthenticationManager.class);
+        this.customDaoAuthenticationFilter.setAuthenticationManager(authenticationManager);
+        this.customDaoAuthenticationFilter.setAuthenticationSuccessHandler(successHandler);
+        registerAuthenticationEntryPoint(http);
+
+        http.addFilterBefore(
+                this.customDaoAuthenticationFilter,
+                UsernamePasswordAuthenticationFilter.class
+        );
+        http.addFilterAfter(
+                this.customSignPageLoadingFilter,
+                CustomDaoAuthenticationFilter.class
+        );
+    }
+
+    @SuppressWarnings("unchecked")
+    public final void registerAuthenticationEntryPoint(HttpSecurity http) {
+        ExceptionHandlingConfigurer<HttpSecurity> exceptionHandling = http.getConfigurer(ExceptionHandlingConfigurer.class);
+        if (exceptionHandling == null) {
+            return;
+        }
+        if (this.authenticationEntryPoint != null) {
+            exceptionHandling.defaultAuthenticationEntryPointFor(
+                    this.authenticationEntryPoint,
+                    new AntPathRequestMatcher(this.signInApiUrl)
+            );
+        }
+    }
+
+    private void setSuccessHandler(HttpSecurity http) {
+        this.successHandler = new CustomDaoAuthenticationSuccessHandler(getJwtEncoder(http));
+    }
+
+    public JwtEncoder getJwtEncoder(HttpSecurity http) {
+        String[] names = http.getSharedObject(ApplicationContext.class).getBeanNamesForType(JwtEncoder.class);
+        if (names.length > 1) {
+            throw new NoUniqueBeanDefinitionException(JwtEncoder.class, names);
+        }
+        if (names.length == 1) {
+            return (JwtEncoder) this.getBuilder()
+                    .getSharedObject(ApplicationContext.class)
+                    .getBean(names[0]);
+        }
+        return null;
+    }
+
+    private void setSignInApiUrl(String signInApiUrl) {
+        this.customDaoAuthenticationFilter.setSignInUrl(signInApiUrl);
+        this.authenticationEntryPoint = new LoginUrlAuthenticationEntryPoint(signInApiUrl);
+        this.signInApiUrl = signInApiUrl;
+    }
+}

--- a/src/main/java/com/example/booksearching/spring/security/authentication/dao/CustomDaoAuthenticationFilter.java
+++ b/src/main/java/com/example/booksearching/spring/security/authentication/dao/CustomDaoAuthenticationFilter.java
@@ -1,0 +1,47 @@
+package com.example.booksearching.spring.security.authentication.dao;
+
+import com.example.booksearching.spring.dto.SignInRequest;
+import com.example.booksearching.spring.exception.SecurityException;
+import com.example.booksearching.spring.exception.SecurityExceptionType;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import lombok.Getter;
+import lombok.Setter;
+import org.springframework.http.HttpMethod;
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.AuthenticationException;
+import org.springframework.security.web.authentication.AbstractAuthenticationProcessingFilter;
+import org.springframework.security.web.util.matcher.AntPathRequestMatcher;
+
+import java.io.IOException;
+
+@Getter
+@Setter
+public class CustomDaoAuthenticationFilter extends AbstractAuthenticationProcessingFilter {
+
+    private ObjectMapper objectMapper = new ObjectMapper();
+
+    public CustomDaoAuthenticationFilter(String setSignInUrl) {
+        super(new AntPathRequestMatcher(setSignInUrl, HttpMethod.POST.name()));
+    }
+
+    public void setSignInUrl(String setSignInUrl) {
+        setRequiresAuthenticationRequestMatcher(new AntPathRequestMatcher(setSignInUrl, HttpMethod.POST.name()));
+    }
+
+    @Override
+    public Authentication attemptAuthentication(HttpServletRequest request, HttpServletResponse response)
+            throws AuthenticationException {
+        try {
+            SignInRequest signInRequest = objectMapper.readValue(request.getReader(), SignInRequest.class);
+            UsernamePasswordAuthenticationToken usernamePasswordAuthenticationToken
+                    = new UsernamePasswordAuthenticationToken(signInRequest.username(), signInRequest.password());
+            return getAuthenticationManager().authenticate(usernamePasswordAuthenticationToken);
+        } catch (IOException e) {
+            throw new SecurityException(SecurityExceptionType.DTO_MAPPING_FAIL);
+        }
+    }
+
+}

--- a/src/main/java/com/example/booksearching/spring/security/authentication/dao/CustomDaoAuthenticationSuccessHandler.java
+++ b/src/main/java/com/example/booksearching/spring/security/authentication/dao/CustomDaoAuthenticationSuccessHandler.java
@@ -1,0 +1,55 @@
+package com.example.booksearching.spring.security.authentication.dao;
+
+import com.example.booksearching.spring.security.UserAccountDetails;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.oauth2.jose.jws.MacAlgorithm;
+import org.springframework.security.oauth2.jwt.*;
+import org.springframework.security.web.authentication.AuthenticationSuccessHandler;
+
+import java.io.IOException;
+import java.time.Instant;
+
+import static com.example.booksearching.spring.security.authentication.SecurityConstants.ACCESS_TOKEN_EXPIRATION;
+import static java.nio.charset.StandardCharsets.UTF_8;
+import static java.time.temporal.ChronoUnit.HOURS;
+import static org.springframework.http.MediaType.APPLICATION_JSON_VALUE;
+
+@RequiredArgsConstructor
+public class CustomDaoAuthenticationSuccessHandler implements AuthenticationSuccessHandler {
+
+    private final JwtEncoder jwtEncoder;
+
+    @Override
+    public void onAuthenticationSuccess(HttpServletRequest request, HttpServletResponse response, Authentication authentication) {
+        response.setContentType(APPLICATION_JSON_VALUE);
+        response.setCharacterEncoding(UTF_8.name());
+        response.setStatus(HttpStatus.OK.value());
+
+
+        Jwt jwt = jwtEncoder.encode(userAccountDetailsToJwtEncoderParameters((UserAccountDetails) authentication.getPrincipal()));
+
+        try {
+            response.getWriter().write("{\"token\":\"" + jwt.getTokenValue() + "\"}");
+        } catch (IOException e) {
+            throw new RuntimeException(e);
+        }
+    }
+
+    public JwtEncoderParameters userAccountDetailsToJwtEncoderParameters(UserAccountDetails userAccountDetails) {
+        JwsHeader jwsHeader = JwsHeader.with(MacAlgorithm.HS256).build();
+
+        // JWT 클레임 생성
+        JwtClaimsSet claimsSet = JwtClaimsSet.builder()
+                .subject(userAccountDetails.getUsername()) // 토큰의 주체 설정
+                .issuedAt(Instant.now())
+                .expiresAt(Instant.now().plus(ACCESS_TOKEN_EXPIRATION, HOURS)) // 토큰 만료 시간 설정 (1시간 후)
+                .build();
+
+        return JwtEncoderParameters.from(jwsHeader, claimsSet);
+    }
+
+}

--- a/src/main/java/com/example/booksearching/spring/security/authentication/dao/CustomSignPageLoadingFilter.java
+++ b/src/main/java/com/example/booksearching/spring/security/authentication/dao/CustomSignPageLoadingFilter.java
@@ -1,0 +1,111 @@
+package com.example.booksearching.spring.security.authentication.dao;
+
+import jakarta.servlet.FilterChain;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.ServletRequest;
+import jakarta.servlet.ServletResponse;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import lombok.Getter;
+import lombok.Setter;
+import org.springframework.core.io.ClassPathResource;
+import org.springframework.util.StreamUtils;
+import org.springframework.web.filter.GenericFilterBean;
+
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+
+@Getter
+@Setter
+public class CustomSignPageLoadingFilter extends GenericFilterBean {
+
+    private String signInPageResourcePath;
+
+    private String signInPageUrl;
+
+    private String signUpPageResourcePath;
+
+    private String signUpPageUrl;
+
+    public CustomSignPageLoadingFilter(String signInPageResourcePath, String signInPageUrl) {
+        this(signInPageResourcePath, signInPageUrl, null, null);
+    }
+
+    public CustomSignPageLoadingFilter(String signInPageResourcePath, String signInPageUrl, String signUpPageResourcePath, String signUpPageUrl) {
+        this.signInPageResourcePath = signInPageResourcePath;
+        this.signInPageUrl = signInPageUrl;
+        this.signUpPageResourcePath = signUpPageResourcePath;
+        this.signUpPageUrl = signUpPageUrl;
+    }
+
+    @Override
+    public void doFilter(ServletRequest request, ServletResponse response, FilterChain chain)
+            throws IOException, ServletException {
+        doFilter((HttpServletRequest) request, (HttpServletResponse) response, chain);
+    }
+
+    private void doFilter(HttpServletRequest request, HttpServletResponse response, FilterChain chain)
+            throws IOException, ServletException {
+        if (isSignInUrlRequest(request)) {
+            String loginPageHtml = loadSignInPageHtml();
+            response.setContentType("text/html;charset=UTF-8");
+            response.setContentLength(loginPageHtml.getBytes(StandardCharsets.UTF_8).length);
+            response.getWriter().write(loginPageHtml);
+            return;
+        }
+        if (isSignUpUrlRequest(request)) {
+            String signUpPageHtml = loadSignUpPageHtml();
+            response.setContentType("text/html;charset=UTF-8");
+            response.setContentLength(signUpPageHtml.getBytes(StandardCharsets.UTF_8).length);
+            response.getWriter().write(signUpPageHtml);
+            return;
+        }
+        chain.doFilter(request, response);
+    }
+
+    private String loadSignInPageHtml() {
+        try {
+            ClassPathResource resource = new ClassPathResource(signInPageResourcePath);
+            return StreamUtils.copyToString(resource.getInputStream(), StandardCharsets.UTF_8);
+        } catch (IOException e) {
+            throw new RuntimeException("Could not read sign-in.html", e);
+        }
+    }
+
+    private boolean isSignInUrlRequest(HttpServletRequest request) {
+        return matches(request, this.signInPageUrl);
+    }
+
+    private String loadSignUpPageHtml() {
+        try {
+            ClassPathResource resource = new ClassPathResource(signUpPageResourcePath);
+            return StreamUtils.copyToString(resource.getInputStream(), StandardCharsets.UTF_8);
+        } catch (IOException e) {
+            throw new RuntimeException("Could not read sign-up.html", e);
+        }
+    }
+
+    private boolean isSignUpUrlRequest(HttpServletRequest request) {
+        return matches(request, this.signUpPageUrl);
+    }
+
+    private boolean matches(HttpServletRequest request, String url) {
+        if (!"GET".equals(request.getMethod()) || url == null) {
+            return false;
+        }
+        String uri = request.getRequestURI();
+        int pathParamIndex = uri.indexOf(';');
+        if (pathParamIndex > 0) {
+            // strip everything after the first semi-colon
+            uri = uri.substring(0, pathParamIndex);
+        }
+        if (request.getQueryString() != null) {
+            uri += "?" + request.getQueryString();
+        }
+        if ("".equals(request.getContextPath())) {
+            return uri.equals(url);
+        }
+        return uri.equals(request.getContextPath() + url);
+    }
+
+}

--- a/src/main/java/com/example/booksearching/spring/security/authentication/jwt/CustomJwtAuthenticationConfigurer.java
+++ b/src/main/java/com/example/booksearching/spring/security/authentication/jwt/CustomJwtAuthenticationConfigurer.java
@@ -1,0 +1,75 @@
+package com.example.booksearching.spring.security.authentication.jwt;
+
+import com.example.booksearching.spring.security.authentication.dao.CustomDaoAuthenticationFilter;
+import jakarta.servlet.http.HttpServletRequest;
+import org.springframework.security.authentication.AuthenticationManager;
+import org.springframework.security.authentication.AuthenticationManagerResolver;
+import org.springframework.security.config.annotation.SecurityConfigurerAdapter;
+import org.springframework.security.config.annotation.web.builders.HttpSecurity;
+import org.springframework.security.oauth2.server.resource.authentication.BearerTokenAuthenticationToken;
+import org.springframework.security.web.DefaultSecurityFilterChain;
+import org.springframework.security.web.authentication.AuthenticationFailureHandler;
+import org.springframework.security.web.authentication.AuthenticationFilter;
+import org.springframework.security.web.authentication.AuthenticationSuccessHandler;
+import org.springframework.security.web.util.matcher.RequestMatcher;
+import org.springframework.util.Assert;
+
+import static com.example.booksearching.spring.security.authentication.SecurityConstants.*;
+
+public class CustomJwtAuthenticationConfigurer extends SecurityConfigurerAdapter<DefaultSecurityFilterChain, HttpSecurity> {
+
+    private final AuthenticationFilter authenticationFilter;
+
+    private AuthenticationSuccessHandler successHandler = (req, res, auth) -> {};
+
+    public CustomJwtAuthenticationConfigurer() {
+        this.authenticationFilter = new AuthenticationFilter(
+                (AuthenticationManagerResolver<HttpServletRequest>) (r) -> null,
+                (HttpServletRequest r) -> {
+                    String token = getAccessToken(r);
+                    if (token == null) {
+                        return null;
+                    }
+                    return new BearerTokenAuthenticationToken(token);
+        });
+    }
+
+    public CustomJwtAuthenticationConfigurer filterProcessesUrl(RequestMatcher filterProcessesUrl) {
+        Assert.notNull(filterProcessesUrl, "filterProcessesUrl must not be null.");
+        this.authenticationFilter.setRequestMatcher(filterProcessesUrl);
+        return this;
+    }
+
+    public CustomJwtAuthenticationConfigurer successHandler(AuthenticationSuccessHandler successHandler) {
+        Assert.notNull(successHandler, "successHandler must not be null.");
+        this.successHandler = successHandler;
+        return this;
+    }
+
+    public CustomJwtAuthenticationConfigurer failureHandler(AuthenticationFailureHandler failureHandler) {
+        Assert.notNull(failureHandler, "failureHandler must not be null.");
+        this.authenticationFilter.setFailureHandler(failureHandler);
+        return this;
+    }
+
+    @Override
+    public void configure(HttpSecurity http) {
+        AuthenticationManager authenticationManager = http.getSharedObject(AuthenticationManager.class);
+        this.authenticationFilter.setAuthenticationManagerResolver(r -> authenticationManager);
+        this.authenticationFilter.setSuccessHandler(successHandler);
+
+        http.addFilterAfter(
+                this.authenticationFilter,
+                CustomDaoAuthenticationFilter.class
+        );
+    }
+
+    private String getAccessToken(HttpServletRequest request) {
+        String accessTokenHeader = request.getHeader(ACCESS_TOKEN_HEADER);
+        if (accessTokenHeader != null && accessTokenHeader.startsWith(BEARER_PREFIX)) {
+            return accessTokenHeader.substring(BEARER_PREFIX_LENGTH);
+        }
+        return null;
+    }
+
+}


### PR DESCRIPTION
# 변경 이유
- Spring Security를 이용하여 요청별 접근 권한 설정 및 인증 방식을 구현하고, 추가

# 변경된 사항
- Rest API와 API의 Controller 분리
  - Rest API Contoller의 경우, url 앞에 "/api"를 추가하였고, Controller에 Api라는 이름을 추가함
  - View를 반환하는 Controller의 경우, url은 그대로 유지하되, Controller에 Page라는 이름을 추가함

- 다음을 정의, 구현
  - SecurityFilterChain
  - PasswordEncoder (BCryptPasswordEncoder로 Bean 등록)
  - Role 계층
  - `UserDetails`, `UserDetailsService` 구현
  - Security에서 발생하는 Excpetion
  - JwtConfig
    - secret key를 이용한 방식의 Jwt를 사용 
 
- CustomDaoAuthenticationConfigurer
  - CustomDaoAuthenticationFilter
  - CustomSignPageLoadingFilter
- CustomJwtAuthenticationConfigurer
  - AuenticationFilter의 `AuthenticationManagerResolver`와 `AuthenticationConverter`를 정의하여 Jwt 인증에 사용
  
- Spring Security 6.2를 사용을 위한 Spring Boot의 버전 업
- 의존성 추가

# 요청 흐름
![SecurityFilterChain](https://github.com/sGOM/book-searching/assets/29831584/ab0e8b4f-da37-4a1b-b961-e8f1abbfcdb5)

### 관련 이슈
- #61
- #30
